### PR TITLE
Log it with dll support [OPCUA-608]

### DIFF
--- a/FrameworkInternals/files.txt
+++ b/FrameworkInternals/files.txt
@@ -219,6 +219,7 @@ File LogSinkInterface.h must_exist,must_be_versioned,md5=aacede0bc224c07148bdaf5
 File LogSinks.h must_exist,must_be_versioned,md5=494fc568661cc91c202ce23f39f80abb,install=overwrite,
 File StdOutLog.h must_exist,must_be_versioned,md5=80f0968b8d1eee8d807c3a84b17b6ddf,install=overwrite,
 File UaTraceSink.h must_exist,must_be_versioned,md5=4b5ef9ae295b67b518d979b4ef05ac05,install=overwrite,
+File LogItInstance.h must_exist,must_be_versioned,install=overwrite,
 Directory LogIt/src install=create,
 File BoostRotatingFileLog.cpp must_exist,must_be_versioned,md5=c89d62f0d44527c024fbd8824ac6ebd0,install=overwrite,
 File ComponentAttributes.cpp must_exist,must_be_versioned,md5=1bf77d02352743804a86664d0212d61d,install=overwrite,
@@ -228,3 +229,4 @@ File LogRecord.cpp must_exist,must_be_versioned,md5=ceef45d72f519aecf9c99199707e
 File LogSinks.cpp must_exist,must_be_versioned,md5=b47c07958f4a26ab01bbde9678b6f754,install=overwrite,
 File StdOutLog.cpp must_exist,must_be_versioned,md5=e257c3384ca8682a2d3923b24fe15889,install=overwrite,
 File UaTraceSink.cpp must_exist,must_be_versioned,md5=cf0c36d77ae170f2eb3b2229bc8f0a06,install=overwrite,
+File LogItInstance.cpp must_exist,must_be_versioned,install=overwrite,

--- a/FrameworkInternals/original_files.txt
+++ b/FrameworkInternals/original_files.txt
@@ -259,6 +259,7 @@ File LogSinkInterface.h  must_exist,must_be_versioned,install=overwrite,md5=chec
 File LogSinks.h  must_exist,must_be_versioned,install=overwrite,md5=check
 File StdOutLog.h  must_exist,must_be_versioned,install=overwrite,md5=check
 File UaTraceSink.h  must_exist,must_be_versioned,install=overwrite,md5=check
+File LogItInstance.h  must_exist,must_be_versioned,install=overwrite,md5=check
 
 Directory LogIt/src install=create,
 File BoostRotatingFileLog.cpp  must_exist,must_be_versioned,install=overwrite,md5=check
@@ -269,4 +270,6 @@ File LogRecord.cpp  must_exist,must_be_versioned,install=overwrite,md5=check
 File LogSinks.cpp  must_exist,must_be_versioned,install=overwrite,md5=check
 File StdOutLog.cpp  must_exist,must_be_versioned,install=overwrite,md5=check
 File UaTraceSink.cpp  must_exist,must_be_versioned,install=overwrite,md5=check
+File LogItInstance.cpp  must_exist,must_be_versioned,install=overwrite,md5=check
+
 

--- a/LogIt/CMakeLists.txt
+++ b/LogIt/CMakeLists.txt
@@ -35,6 +35,7 @@ set(LOGIT_SOURCES
     src/LogRecord.cpp
     src/LogSinks.cpp
     src/ComponentAttributes.cpp
+    src/LogItInstance.cpp
 )    
 
 if(${LOGIT_HAS_BOOSTLOG})
@@ -51,6 +52,8 @@ if(${LOGIT_HAS_UATRACE})
     add_definitions(-DLOGIT_HAS_UATRACE)
     set(LOGIT_SOURCES ${LOGIT_SOURCES} src/UaTraceSink.cpp)
 endif(${LOGIT_HAS_UATRACE})
+
+set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 
 MESSAGE( STATUS "building LogIt from source files [${LOGIT_SOURCES}]" )
 add_library (LogIt OBJECT ${LOGIT_SOURCES})

--- a/LogIt/include/BoostRotatingFileLog.h
+++ b/LogIt/include/BoostRotatingFileLog.h
@@ -24,6 +24,7 @@
 
 #include <string>
 #include "LogSinkInterface.h"
+#include <boost/log/sources/logger.hpp>
 
 class BoostRotatingFileLog : public LogSinkInterface
 {
@@ -33,6 +34,7 @@ public:
 
 private:
     void addFileSink();
+	boost::log::sources::logger_mt m_boostLogger;
 };
 
 #endif /* BOOST_ROTATING_FILE_LOG_H_ */

--- a/LogIt/include/LogIt.h
+++ b/LogIt/include/LogIt.h
@@ -28,6 +28,7 @@
 #include "LogRecord.h"
 #include "LogLevels.h"
 #include "ComponentAttributes.h"
+#include "LogItInstance.h"
 
 const uint32_t g_sMaxComponentIdCount = 1024;
 
@@ -60,6 +61,8 @@ namespace Log
      * logging is initialized once, logging thresholds (for non-component and component verbosity) can be set
      * at any time (by any thread).
      */
+
+	bool initializeDllLogging(LogItInstance* remoteLogInstance);
 
     /**
      * Simple initializer, without component specific logging. Only

--- a/LogIt/include/LogIt.h
+++ b/LogIt/include/LogIt.h
@@ -62,8 +62,6 @@ namespace Log
      * at any time (by any thread).
      */
 
-	bool initializeDllLogging(LogItInstance* remoteLogInstance);
-
     /**
      * Simple initializer, without component specific logging. Only
      * LOG(LOG_LEVEL)
@@ -81,6 +79,16 @@ namespace Log
      * (i.e. for component IDs specified in the vector of components).
      */
     bool initializeLogging(const Log::LOG_LEVEL& nonComponentLogLevel, const std::list<ComponentAttributes>& components);
+
+	/**
+	 * initializer to be called when using LogIt *inside* a shared library. The remoteLogInstance ptr should be supplied
+	 * to the shared library from the main executable (note that this will probably require that the shared library API supports
+	 * passing this ptr *before* the shared library can initialize the logger and start logging).
+	 *
+	 * The ptr (in the main executable, to pass to the DLL) is available from LogItInstance::getInstance() after the exe
+	 * calls LogIt::initialiseLogging().
+	 */
+	bool initializeDllLogging(LogItInstance* remoteLogInstance);
 
     /**
      * log check - non-component (single-arg) and component (double-arg) specific

--- a/LogIt/include/LogItInstance.h
+++ b/LogIt/include/LogItInstance.h
@@ -1,0 +1,36 @@
+/*
+ * LogItInstance.h
+ *
+ *  Created on: Apr 4, 2016
+ *      Author: bfarnham
+ */
+
+#ifndef THEDYNLIB_LOGIT_LOGITINSTANCE_H_
+#define THEDYNLIB_LOGIT_LOGITINSTANCE_H_
+
+#include <map>
+#include "LogLevels.h"
+#include "ComponentAttributes.h"
+#include "LogSinks.h"
+
+class LogItInstance
+{
+public:
+	static bool instanceExists();
+	static LogItInstance* getInstance();
+	static bool setInstance(LogItInstance* remoteInstance);
+	static LogItInstance* createInstance();
+
+	bool m_isLoggingInitialized;
+	LogSinks m_logSinksInstance;
+	std::map<uint32_t, ComponentAttributes> m_sComponents;
+	Log::LOG_LEVEL m_nonComponentLogLevel;
+
+private:
+	LogItInstance();
+	virtual ~LogItInstance();
+
+	static LogItInstance* g_sLogItInstance;
+};
+
+#endif /* THEDYNLIB_LOGIT_LOGITINSTANCE_H_ */

--- a/LogIt/include/LogSinks.h
+++ b/LogIt/include/LogSinks.h
@@ -29,8 +29,8 @@
 class LogSinks
 {
 public:
-    static LogSinks* g_sLogSinksInstance;
-
+	LogSinks();
+	virtual ~LogSinks();
     void addSink(LogSinkInterface* sink);
     void logMessage(const std::string& logMsg);
 

--- a/LogIt/src/BoostRotatingFileLog.cpp
+++ b/LogIt/src/BoostRotatingFileLog.cpp
@@ -26,7 +26,6 @@
 #include <boost/log/core/core.hpp>
 
 #include <boost/log/sources/record_ostream.hpp>
-#include <boost/log/sources/logger.hpp>
 #include <boost/log/core/record.hpp>
 #include <boost/log/sources/logger.hpp>
 #include <boost/log/common.hpp>
@@ -44,10 +43,8 @@ using sinks::text_file_backend;
 
 const std::string fileNamePattern = "file_%5N.log";
 const std::string logDirectory = "log";
-const size_t maxLogFileSizeBytes = 5000;
+const size_t maxLogFileSizeBytes = 5000000;
 const size_t maxLogFileCount = 10;
-
-boost::log::sources::logger_mt g_sTheLogger;
 
 bool BoostRotatingFileLog::initialize()
 {
@@ -57,14 +54,14 @@ bool BoostRotatingFileLog::initialize()
 
 void BoostRotatingFileLog::logMessage(const std::string& logEntry)
 {
-    boost::log::record record = g_sTheLogger.open_record();
+    boost::log::record record = m_boostLogger.open_record();
 
     if(record)
     {
         boost::log::record_ostream stream(record);
         stream << logEntry;
         stream.flush();
-        g_sTheLogger.push_record(boost::move(record));
+		m_boostLogger.push_record(boost::move(record));
     }
 }
 

--- a/LogIt/src/LogIt.cpp
+++ b/LogIt/src/LogIt.cpp
@@ -27,6 +27,7 @@
 #include "ComponentAttributes.h"
 #include "LogSinks.h"
 #include "LogLevels.h"
+#include "LogItInstance.h"
 
 #ifdef LOGIT_HAS_BOOSTLOG
 #include "BoostRotatingFileLog.h"
@@ -40,77 +41,79 @@
 #include <UaTraceSink.h>
 #endif
 
-bool g_sLoggingInitialized = false;
-Log::LOG_LEVEL g_sNonComponentLogLevel(Log::INF);
-std::map<uint32_t, ComponentAttributes> g_sComponents;
-
 // internal - not exposed via API
 void initializeSinks()
 {
-    LogSinks::g_sLogSinksInstance = new LogSinks();
+	if(!LogItInstance::instanceExists()) return;
 
 	#ifdef LOGIT_HAS_BOOSTLOG
     BoostRotatingFileLog* fileLogger = new BoostRotatingFileLog();
     fileLogger->initialize();
-    LogSinks::g_sLogSinksInstance->addSink(fileLogger);
+    LogItInstance::getInstance()->m_logSinksInstance.addSink(fileLogger);
 	#endif // LOGIT_HAS_BOOSTLOG
 
 	#ifdef LOGIT_HAS_STDOUTLOG
     StdOutLog * stdOutLog = new StdOutLog();
     stdOutLog->initialize();
-    LogSinks::g_sLogSinksInstance->addSink(stdOutLog);
+    LogItInstance::getInstance()->m_logSinksInstance.addSink(stdOutLog);
 	#endif
 
 	#ifdef LOGIT_HAS_UATRACE
     UaTraceSink * uaTraceSink = new UaTraceSink ();
     uaTraceSink->initialize();
-    LogSinks::g_sLogSinksInstance->addSink(uaTraceSink);
+    LogItInstance::getInstance()->m_logSinksInstance.addSink(uaTraceSink);
     #endif
 }
+
 
 // internal - not exposed via API.
 void registerComponents(const std::list<ComponentAttributes>& components)
 {
+	if(!LogItInstance::instanceExists()) return;
     for(std::list<ComponentAttributes>::const_iterator it = components.begin(); it != components.end(); ++it)
     {
         ComponentAttributes component = *it;
-        g_sComponents.insert( std::map<uint32_t, ComponentAttributes>::value_type(component.getId(), component) );
+        LogItInstance::getInstance()->m_sComponents.insert( std::map<uint32_t, ComponentAttributes>::value_type(component.getId(), component) );
     }
+}
+
+bool Log::initializeDllLogging(LogItInstance* remoteInstance)
+{
+	if(!remoteInstance)
+	{
+		std::cerr << "initializeDllLogging called with invalid remote remoteInstance ptr ["<<remoteInstance<<"], logger initialization failed" << std::endl;
+		return false;
+	}
+
+	std::cout << "initializing logging in a DLL" << std::endl;
+	return LogItInstance::setInstance(remoteInstance);
 }
 
 bool Log::initializeLogging(const Log::LOG_LEVEL& nonComponentLogLevel)
 {
-    if(g_sLoggingInitialized) return false;
-
+	if(LogItInstance::instanceExists()) return false;
+	LogItInstance::createInstance();
     initializeSinks();
-
     setNonComponentLogLevel(nonComponentLogLevel);
-    g_sLoggingInitialized = true;
     return true;
 }
 
 bool Log::initializeLogging(const Log::LOG_LEVEL& nonComponentLogLevel, const std::list<ComponentAttributes>& components)
 {
-    if(g_sLoggingInitialized) return false;
-
-    initializeSinks();
-
+	if(!initializeLogging(nonComponentLogLevel)) return false;
     registerComponents(components);
-    setNonComponentLogLevel(nonComponentLogLevel);
-
-    g_sLoggingInitialized = true;
-    return true;
+    return true;;
 }
 
 bool Log::isLoggable(const Log::LOG_LEVEL& level)
 {
-    if(!g_sLoggingInitialized) return false;
-    return level >= g_sNonComponentLogLevel;
+    if(!LogItInstance::instanceExists()) return false;
+    return level >= LogItInstance::getInstance()->m_nonComponentLogLevel;
 }
 
 bool Log::isLoggable(const Log::LOG_LEVEL& level, const uint32_t& componentId)
 {
-    if(!g_sLoggingInitialized) return false;
+	if(!LogItInstance::instanceExists()) return false;
 
     LOG_LEVEL componentLogLevel;
     if(!getComponentLogLevel(componentId, componentLogLevel)) return false; // unregistered component id.
@@ -120,21 +123,24 @@ bool Log::isLoggable(const Log::LOG_LEVEL& level, const uint32_t& componentId)
 
 void Log::setNonComponentLogLevel(const LOG_LEVEL& level)
 {
-    if(g_sNonComponentLogLevel != level)
+	if(!LogItInstance::instanceExists()) return;
+    if(LogItInstance::getInstance()->m_nonComponentLogLevel != level)
     {
-        g_sNonComponentLogLevel = level;
+    	LogItInstance::getInstance()->m_nonComponentLogLevel = level;
     }
 }
 
 Log::LOG_LEVEL Log::getNonComponentLogLevel(void)
 {
-    return g_sNonComponentLogLevel;
+	return LogItInstance::getInstance()->m_nonComponentLogLevel;
 }
 
 const std::list<ComponentAttributes> Log::getComponentLogsList()
 {
 	std::list<ComponentAttributes> result;
-	for(std::map<uint32_t, ComponentAttributes>::const_iterator it = g_sComponents.begin(); it != g_sComponents.end(); ++it)
+	if(!LogItInstance::instanceExists()) return result; // empty
+
+	for(std::map<uint32_t, ComponentAttributes>::const_iterator it = LogItInstance::getInstance()->m_sComponents.begin(); it != LogItInstance::getInstance()->m_sComponents.end(); ++it)
 	{
 		result.push_back(it->second);
 	}
@@ -143,8 +149,10 @@ const std::list<ComponentAttributes> Log::getComponentLogsList()
 
 bool Log::setComponentLogLevel(const uint32_t& componentId, const LOG_LEVEL& level)
 {
-    std::map<uint32_t, ComponentAttributes>::iterator pos = g_sComponents.find(componentId);
-    if(pos == g_sComponents.end()) return false;
+	if(!LogItInstance::instanceExists()) return false;
+
+    std::map<uint32_t, ComponentAttributes>::iterator pos = LogItInstance::getInstance()->m_sComponents.find(componentId);
+    if(pos == LogItInstance::getInstance()->m_sComponents.end()) return false;
 
     pos->second.setLevel(level);
     return true;
@@ -152,8 +160,10 @@ bool Log::setComponentLogLevel(const uint32_t& componentId, const LOG_LEVEL& lev
 
 bool Log::getComponentLogLevel(const uint32_t& componentId, LOG_LEVEL& level)
 {
-    std::map<uint32_t, ComponentAttributes>::const_iterator pos =  g_sComponents.find(componentId);
-    if(pos == g_sComponents.end()) return false;
+	if(!LogItInstance::instanceExists()) return false;
+
+	std::map<uint32_t, ComponentAttributes>::const_iterator pos = LogItInstance::getInstance()->m_sComponents.find(componentId);
+    if(pos == LogItInstance::getInstance()->m_sComponents.end()) return false;
 
     level = pos->second.getLevel();
     return true;
@@ -161,8 +171,10 @@ bool Log::getComponentLogLevel(const uint32_t& componentId, LOG_LEVEL& level)
 
 void Log::setGlobalLogLevel(const LOG_LEVEL& level)
 {
-    g_sNonComponentLogLevel = level;
-    for(std::map<uint32_t, ComponentAttributes>::iterator pos = g_sComponents.begin(); pos != g_sComponents.end(); ++pos)
+	if(!LogItInstance::instanceExists()) return;
+
+	LogItInstance::getInstance()->m_nonComponentLogLevel = level;
+    for(std::map<uint32_t, ComponentAttributes>::iterator pos = LogItInstance::getInstance()->m_sComponents.begin(); pos != LogItInstance::getInstance()->m_sComponents.end(); ++pos)
     {
         pos->second.setLevel(level);
     }
@@ -170,8 +182,10 @@ void Log::setGlobalLogLevel(const LOG_LEVEL& level)
 
 std::string Log::componentIdToString(const uint32_t& componentId)
 {
-    std::map<uint32_t, ComponentAttributes>::iterator pos = g_sComponents.find(componentId);
-    if(pos == g_sComponents.end()) return "UNKNOWN";
+	if(!LogItInstance::instanceExists()) return "UNKNOWN";
+
+    std::map<uint32_t, ComponentAttributes>::iterator pos = LogItInstance::getInstance()->m_sComponents.find(componentId);
+    if(pos == LogItInstance::getInstance()->m_sComponents.end()) return "UNKNOWN";
 
     return pos->second.getName();
 }

--- a/LogIt/src/LogIt.cpp
+++ b/LogIt/src/LogIt.cpp
@@ -77,17 +77,6 @@ void registerComponents(const std::list<ComponentAttributes>& components)
     }
 }
 
-bool Log::initializeDllLogging(LogItInstance* remoteInstance)
-{
-	if(!remoteInstance)
-	{
-		std::cerr << "initializeDllLogging called with invalid remote remoteInstance ptr ["<<remoteInstance<<"], logger initialization failed" << std::endl;
-		return false;
-	}
-
-	std::cout << "initializing logging in a DLL" << std::endl;
-	return LogItInstance::setInstance(remoteInstance);
-}
 
 bool Log::initializeLogging(const Log::LOG_LEVEL& nonComponentLogLevel)
 {
@@ -103,6 +92,11 @@ bool Log::initializeLogging(const Log::LOG_LEVEL& nonComponentLogLevel, const st
 	if(!initializeLogging(nonComponentLogLevel)) return false;
     registerComponents(components);
     return true;;
+}
+
+bool Log::initializeDllLogging(LogItInstance* remoteInstance)
+{
+	return LogItInstance::setInstance(remoteInstance);
 }
 
 bool Log::isLoggable(const Log::LOG_LEVEL& level)

--- a/LogIt/src/LogItInstance.cpp
+++ b/LogIt/src/LogItInstance.cpp
@@ -1,0 +1,53 @@
+/*
+ * LogItInstance.cpp
+ *
+ *  Created on: Apr 4, 2016
+ *      Author: bfarnham
+ */
+
+#include "LogItInstance.h"
+#include <iostream>
+
+LogItInstance* LogItInstance::g_sLogItInstance(NULL); // initially
+
+LogItInstance::LogItInstance()
+:m_isLoggingInitialized(false), m_nonComponentLogLevel(Log::INF)
+{}
+
+LogItInstance::~LogItInstance()
+{}
+
+bool LogItInstance::instanceExists()
+{
+	return LogItInstance::g_sLogItInstance != NULL;
+}
+
+LogItInstance* LogItInstance::getInstance()
+{
+	return LogItInstance::g_sLogItInstance;
+}
+
+bool LogItInstance::setInstance(LogItInstance* remoteInstance)
+{
+	if(instanceExists())
+	{
+		std::cerr << "Failed to set LogItInstance with remoteInstance ["<<remoteInstance<<"], already have incumbent instance ["<<getInstance()<<"]. Ignoring (and returning false)";
+		return false;
+	}
+	LogItInstance::g_sLogItInstance = remoteInstance;
+	return true;
+}
+
+LogItInstance* LogItInstance::createInstance()
+{
+	if(instanceExists())
+	{
+		std::cerr << "Failed to create new LogItInstance, already have instance ["<<getInstance()<<"]. Ignoring (and returning instance)";
+		return false;
+	}
+
+	LogItInstance::g_sLogItInstance = new LogItInstance();
+	return LogItInstance::g_sLogItInstance;
+}
+
+

--- a/LogIt/src/LogItInstance.cpp
+++ b/LogIt/src/LogItInstance.cpp
@@ -8,7 +8,7 @@
 #include "LogItInstance.h"
 #include <iostream>
 
-LogItInstance* LogItInstance::g_sLogItInstance(NULL); // initially
+LogItInstance* LogItInstance::g_sLogItInstance(NULL); // initially - set by any LogIt::initialize*Logging() call.
 
 LogItInstance::LogItInstance()
 :m_isLoggingInitialized(false), m_nonComponentLogLevel(Log::INF)

--- a/LogIt/src/LogItInstance.cpp
+++ b/LogIt/src/LogItInstance.cpp
@@ -29,6 +29,7 @@ LogItInstance* LogItInstance::getInstance()
 
 bool LogItInstance::setInstance(LogItInstance* remoteInstance)
 {
+	if(!remoteInstance) return false;
 	if(instanceExists())
 	{
 		std::cerr << "Failed to set LogItInstance with remoteInstance ["<<remoteInstance<<"], already have incumbent instance ["<<getInstance()<<"]. Ignoring (and returning false)";

--- a/LogIt/src/LogItInstance.cpp
+++ b/LogIt/src/LogItInstance.cpp
@@ -8,6 +8,9 @@
 #include "LogItInstance.h"
 #include <iostream>
 
+using std::cerr;
+using std::endl;
+
 LogItInstance* LogItInstance::g_sLogItInstance(NULL); // initially - set by any LogIt::initialize*Logging() call.
 
 LogItInstance::LogItInstance()
@@ -29,13 +32,18 @@ LogItInstance* LogItInstance::getInstance()
 
 bool LogItInstance::setInstance(LogItInstance* remoteInstance)
 {
-	if(!remoteInstance) return false;
-	if(instanceExists())
+	if(!remoteInstance)
 	{
-		std::cerr << "Failed to set LogItInstance with remoteInstance ["<<remoteInstance<<"], already have incumbent instance ["<<getInstance()<<"]. Ignoring (and returning false)";
+		cerr << "Failed to set LogItInstance with NULL remoteInstance. Ignoring (and returning false)" << endl;
 		return false;
 	}
-	LogItInstance::g_sLogItInstance = remoteInstance;
+	if(instanceExists())
+	{
+		if(getInstance() == remoteInstance) return true; // fine - do nothing.
+		cerr << "Failed to set LogItInstance with remoteInstance ["<<remoteInstance<<"], already have incumbent instance ["<<getInstance()<<"]. Ignoring (and returning false)" << endl;
+		return false;
+	}
+	g_sLogItInstance = remoteInstance;
 	return true;
 }
 
@@ -43,12 +51,13 @@ LogItInstance* LogItInstance::createInstance()
 {
 	if(instanceExists())
 	{
-		std::cerr << "Failed to create new LogItInstance, already have instance ["<<getInstance()<<"]. Ignoring (and returning instance)";
-		return false;
+		std::cerr << "Failed to create new LogItInstance, already have instance ["<<getInstance()<<"]. Ignoring (and returning instance)" << endl;
 	}
-
-	LogItInstance::g_sLogItInstance = new LogItInstance();
-	return LogItInstance::g_sLogItInstance;
+	else
+	{
+		g_sLogItInstance = new LogItInstance();
+	}
+	return getInstance();
 }
 
 

--- a/LogIt/src/LogRecord.cpp
+++ b/LogIt/src/LogRecord.cpp
@@ -20,7 +20,7 @@
  */
 
 #include "LogRecord.h"
-#include "LogSinks.h"
+#include "LogItInstance.h"
 #include "LogIt.h"
 
 #include <boost/date_time/posix_time/posix_time.hpp>
@@ -49,7 +49,7 @@ LogRecord::LogRecord(const string& file, const int& line, const Log::LOG_LEVEL& 
 LogRecord::~LogRecord()
 {
     m_stream.flush();
-    LogSinks::g_sLogSinksInstance->logMessage(m_stream.str());
+    LogItInstance::getInstance()->m_logSinksInstance.logMessage(m_stream.str());
 }
 
 std::ostringstream& LogRecord::initializeStream(const string& file, const int& line, const Log::LOG_LEVEL& level)

--- a/LogIt/src/LogSinks.cpp
+++ b/LogIt/src/LogSinks.cpp
@@ -22,8 +22,23 @@
 
 using std::vector;
 
-LogSinks* LogSinks::g_sLogSinksInstance;
+LogSinks::LogSinks()
+{}
 
+/**
+ * Clean up sink memory.
+ */
+LogSinks::~LogSinks()
+{
+    for(vector<LogSinkInterface*>::iterator it = m_sinks.begin(); it!= m_sinks.end(); ++it)
+    {
+        delete *it;
+    }
+}
+
+/**
+ * Ownership of the sink is transferred to this object (deleted in the ~dtor)
+ */
 void LogSinks::addSink(LogSinkInterface* sink)
 {
     m_sinks.push_back(sink);


### PR DESCRIPTION
From the JIRA item:


Observed behaviour on windows:

When using dynamically loaded libraries (dlls), for example, LogIt calls to log messages does not work. Specifically this was noticed during the course of the work involving the 'CAN Common Component', which loads so/dll libraries containing implementation code for a specific CAN gateway.
