### PR TITLE
[OPCUA-611] Fix for debug builds sometimes stopping with abort() call

### DIFF
--- a/Meta/src/Base_DComponentLogLevel.cpp
+++ b/Meta/src/Base_DComponentLogLevel.cpp
@@ -50,6 +50,7 @@ unsigned int Base_DComponentLogLevel::unlinkAllChildren ()
 }
 
 Base_DComponentLogLevel::Base_DComponentLogLevel ()
+:m_addressSpaceLink(0)
 {}
 
 Base_DComponentLogLevel::~Base_DComponentLogLevel ()


### PR DESCRIPTION
Fix for OPCUA-611, initialize uninitialized variable - stops call to abort() on startup. Only affects debug builds.