### PR TITLE
Bugfix in shutdown.cpp (file provided by unified automation)

### DIFF
--- a/Server/src/shutdown.cpp
+++ b/Server/src/shutdown.cpp
@@ -20,12 +20,14 @@
 # ifndef WIN32
 #  include <unistd.h>
 #  include <limits.h> 
+# else
+#  include <windows.h>
 # endif
 
 /* shutdown flag */
 static volatile unsigned int g_ShutDown = 0;
 #ifdef _WIN32_WCE
-	# include <windows.h>	 
+		 
 #elif defined(_WIN32) && !defined(USE_CTRLC_ON_WINDOWS)
 #  include <conio.h> /* DOS header for _kbhit() and _getch() */
 #endif
@@ -98,7 +100,7 @@ void RegisterSignalHandler()
  * Windows CTRL-C Handler implementation. *
  ******************************************/
 # ifdef USE_CTRLC_ON_WINDOWS
-#  include <windows.h>
+#  
 #  include <conio.h>
 BOOL CtrlHandler(DWORD fdwCtrlType) 
 {


### PR DESCRIPTION
Fixed a bug in shutdown.cpp (file provided by unified automation) in which, in some version of windows, if a set of specific conditions is met, windows.h will not be included and the file will fail to compile, since it is needed to resolve the variable MAX_PATH.
In the bugfix, windows.h will be included if the macro WIN32 exists (ergo, the system is a windows machine).
Bug defined in jira issue OPCUA-616.