### PR TITLE
Python improvements on the error handling (and more)

### DIFF
--- a/FrameworkInternals/addressSpaceGenerators.py
+++ b/FrameworkInternals/addressSpaceGenerators.py
@@ -20,7 +20,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 '''
 
 import os
-import subprocess
 import platform
 from transformDesign import transformDesignVerbose
 asPath = "AddressSpace" + os.path.sep

--- a/FrameworkInternals/automated_build.py
+++ b/FrameworkInternals/automated_build.py
@@ -20,10 +20,11 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 '''
 
 import os
-import subprocess
 import platform
 import __main__
 from generateCmake import generateCmake
+from externalToolCheck import subprocessWithImprovedErrors
+from externalToolCheck import getVcvarsallPath
 
 def findFileRecursively( topdir, target ):
 	for dirpath, dirnames, files in os.walk(topdir):
@@ -51,16 +52,16 @@ def automatedBuild(BUILD_TYPE="Release", CMAKE_TOOLCHAIN_FILE="FrameworkInternal
 	print('Calling make/msbuild')
 	if platform.system() == "Windows":
 		print('Calling visual studio vcvarsall to set the environment')
-		print('"C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat" amd64')
-		returnCode = subprocess.call('"C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat" amd64', shell=True)
+		print(getVcvarsallPath() + ' amd64')
+		returnCode = subprocessWithImprovedErrors( getVcvarsallPath() + ' amd64', "visual studio vcvarsall.bat")
 		if returnCode != 0:
 			print('ERROR: vcvarsall could not be executed, maybe the installation folder is different than the one expected? [C:\Program Files (x86)\Microsoft Visual Studio 12.0]')			
 			return returnCode
 		print('msbuild ALL_BUILD.vcxproj /clp:ErrorsOnly /property:Platform=x64;Configuration=' + BUILD_TYPE)
-		returnCode = subprocess.call('"C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat" amd64 && msbuild ALL_BUILD.vcxproj /clp:ErrorsOnly /property:Platform=x64;Configuration=' + BUILD_TYPE, shell=True)
+		returnCode = subprocessWithImprovedErrors( getVcvarsallPath() + ' amd64 && msbuild ALL_BUILD.vcxproj /clp:ErrorsOnly /property:Platform=x64;Configuration=' + BUILD_TYPE, "visual studio msbuild")
 	elif platform.system() == "Linux":
 		print('make -j$(nproc)')
-		returnCode = subprocess.call('make -j$(nproc)', shell=True)
+		returnCode = ssubprocessWithImprovedErrors('make -j$(nproc)', "make")
 	if returnCode != 0:
 		print("Error returned from calling make/msbuild; Return code = " + str(returnCode))
 	return returnCode

--- a/FrameworkInternals/automated_build.py
+++ b/FrameworkInternals/automated_build.py
@@ -25,7 +25,7 @@ import subprocess
 import __main__
 from generateCmake import generateCmake
 from externalToolCheck import subprocessWithImprovedErrors
-from externalToolCheck import getVcvarsallPath
+from commandMap import getCommand
 
 def findFileRecursively( topdir, target ):
 	for dirpath, dirnames, files in os.walk(topdir):
@@ -53,20 +53,20 @@ def automatedBuild(BUILD_TYPE="Release", CMAKE_TOOLCHAIN_FILE="FrameworkInternal
 	print('Calling make/msbuild')
 	if platform.system() == "Windows":
 		print('Calling visual studio vcvarsall to set the environment')
-		print(getVcvarsallPath() + ' amd64')
-		returnCode = subprocessWithImprovedErrors( getVcvarsallPath() + ' amd64', "visual studio vcvarsall.bat")
+		print(getCommand("vcvarsall.simple") + ' amd64')
+		returnCode = subprocessWithImprovedErrors( getCommand("vcvarsall") + ' amd64', "visual studio vcvarsall.bat")
 		if returnCode != 0:
-			print('ERROR: vcvarsall could not be executed, maybe the installation folder is different than the one expected? [C:\Program Files (x86)\Microsoft Visual Studio 12.0]')			
+			print('ERROR: vcvarsall could not be executed, maybe the installation folder is different than the one expected? [' + getCommand("vcvarsall.simple") + ']')			
 			return returnCode
 		print('msbuild ALL_BUILD.vcxproj /clp:ErrorsOnly /property:Platform=x64;Configuration=' + BUILD_TYPE)
-		returnCode = subprocessWithImprovedErrors( getVcvarsallPath() + ' amd64 && msbuild ALL_BUILD.vcxproj /clp:ErrorsOnly /property:Platform=x64;Configuration=' + BUILD_TYPE, "visual studio msbuild")
+		returnCode = subprocessWithImprovedErrors( getCommand("vcvarsall") + ' amd64 && msbuild ALL_BUILD.vcxproj /clp:ErrorsOnly /property:Platform=x64;Configuration=' + BUILD_TYPE, "visual studio msbuild")
 	elif platform.system() == "Linux":
 		print('make -j$(nproc)')
 		#we call process nproc and store its output
 		process = subprocess.Popen(["nproc"], stdout=subprocess.PIPE)
 		out, err = process.communicate()
 		#this output is used for calling make
-		returnCode = subprocessWithImprovedErrors(["make", "-j" + str(int(out))], "make")#the conversion from string to int and back to string is to remove all whitespaces and ensure that we have an integer
+		returnCode = subprocessWithImprovedErrors([getCommand("make"), "-j" + str(int(out))], getCommand("make"))#the conversion from string to int and back to string is to remove all whitespaces and ensure that we have an integer
 	if returnCode != 0:
 		print("Error returned from calling make/msbuild; Return code = " + str(returnCode))
 	return returnCode

--- a/FrameworkInternals/automated_build.py
+++ b/FrameworkInternals/automated_build.py
@@ -21,6 +21,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 import os
 import platform
+import subprocess
 import __main__
 from generateCmake import generateCmake
 from externalToolCheck import subprocessWithImprovedErrors
@@ -61,7 +62,11 @@ def automatedBuild(BUILD_TYPE="Release", CMAKE_TOOLCHAIN_FILE="FrameworkInternal
 		returnCode = subprocessWithImprovedErrors( getVcvarsallPath() + ' amd64 && msbuild ALL_BUILD.vcxproj /clp:ErrorsOnly /property:Platform=x64;Configuration=' + BUILD_TYPE, "visual studio msbuild")
 	elif platform.system() == "Linux":
 		print('make -j$(nproc)')
-		returnCode = ssubprocessWithImprovedErrors('make -j$(nproc)', "make")
+		#we call process nproc and store its output
+		process = subprocess.Popen(["nproc"], stdout=subprocess.PIPE)
+		out, err = process.communicate()
+		#this output is used for calling make
+		returnCode = subprocessWithImprovedErrors(["make", "-j" + str(int(out))], "make")#the conversion from string to int and back to string is to remove all whitespaces and ensure that we have an integer
 	if returnCode != 0:
 		print("Error returned from calling make/msbuild; Return code = " + str(returnCode))
 	return returnCode

--- a/FrameworkInternals/configurationGenerators.py
+++ b/FrameworkInternals/configurationGenerators.py
@@ -25,6 +25,7 @@ import subprocess
 import shutil
 from transformDesign import transformDesignVerbose
 from externalToolCheck import subprocessWithImprovedErrorsPipeOutputToFile
+from commandMap import getCommand
 
 configPath = "Configuration" + os.path.sep	
 def generateConfiguration():
@@ -33,7 +34,7 @@ def generateConfiguration():
 	returnCode = transformDesignVerbose(configPath + "designToConfigurationXSD.xslt", configPath + output, 0, 0)
 	print("Calling xmllint to modify " + output)
 	#this call is not using subprocess with improved errors because of the need of the piping.
-	returnCode = subprocessWithImprovedErrorsPipeOutputToFile(["xmllint", "--xinclude", configPath + output], configPath + output + ".new", "xmllint")
+	returnCode = subprocessWithImprovedErrorsPipeOutputToFile([getCommand("xmllint"), "--xinclude", configPath + output], configPath + output + ".new", getCommand("xmllint"))
 	if returnCode != 0:
 		print("ERROR: There was an problem executing xmllint")
 		return returnCode

--- a/FrameworkInternals/configurationGenerators.py
+++ b/FrameworkInternals/configurationGenerators.py
@@ -21,9 +21,10 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 import os
 import platform
+import subprocess
 import shutil
 from transformDesign import transformDesignVerbose
-from externalToolCheck import subprocessWithImprovedErrors
+from externalToolCheck import subprocessWithImprovedErrorsPipeOutputToFile
 
 configPath = "Configuration" + os.path.sep	
 def generateConfiguration():
@@ -31,7 +32,8 @@ def generateConfiguration():
 	output = "Configuration.xsd"
 	returnCode = transformDesignVerbose(configPath + "designToConfigurationXSD.xslt", configPath + output, 0, 0)
 	print("Calling xmllint to modify " + output)
-	returnCode = subprocessWithImprovedErrors("xmllint --xinclude " + configPath + output + " > " + configPath + output + ".new", "xmllint")
+	#this call is not using subprocess with improved errors because of the need of the piping.
+	returnCode = subprocessWithImprovedErrorsPipeOutputToFile(["xmllint", "--xinclude", configPath + output], configPath + output + ".new", "xmllint")
 	if returnCode != 0:
 		print("ERROR: There was an problem executing xmllint")
 		return returnCode

--- a/FrameworkInternals/configurationGenerators.py
+++ b/FrameworkInternals/configurationGenerators.py
@@ -20,10 +20,10 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 '''
 
 import os
-import subprocess
 import platform
 import shutil
 from transformDesign import transformDesignVerbose
+from externalToolCheck import subprocessWithImprovedErrors
 
 configPath = "Configuration" + os.path.sep	
 def generateConfiguration():
@@ -31,7 +31,7 @@ def generateConfiguration():
 	output = "Configuration.xsd"
 	returnCode = transformDesignVerbose(configPath + "designToConfigurationXSD.xslt", configPath + output, 0, 0)
 	print("Calling xmllint to modify " + output)
-	returnCode = subprocess.call("xmllint --xinclude " + configPath + output + " > " + configPath + output + ".new", shell=True)
+	returnCode = subprocessWithImprovedErrors("xmllint --xinclude " + configPath + output + " > " + configPath + output + ".new", "xmllint")
 	if returnCode != 0:
 		print("ERROR: There was an problem executing xmllint")
 		return returnCode

--- a/FrameworkInternals/designTools.py
+++ b/FrameworkInternals/designTools.py
@@ -20,11 +20,11 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 '''
 
 import os
-import subprocess
 import platform
 import shutil
 import __main__
 from transformDesign import transformDesignVerbose
+from externalToolCheck import subprocessWithImprovedErrors
 
 designPath = "Design" + os.path.sep
 designXML = "Design.xml"
@@ -38,7 +38,7 @@ def validateDesign():
 	# This allows some basic checks
 	print("1st line of check -- XSD conformance")
 	print("Validating the file " + designXML + " with the schema " + designXSD)
-	returnCode = subprocess.call("xmllint --noout --schema " + designPath + designXSD + " " + designPath + designXML, shell=True)
+	returnCode = subprocessWithImprovedErrors("xmllint --noout --schema " + designPath + designXSD + " " + designPath + designXML, "xmllint")
 	if returnCode != 0:
 		print("There was a problem validating the file" + designXML + " with the schema " + designXSD + "; Return code = " + str(returnCode))
 		return returnCode
@@ -61,9 +61,9 @@ def formatDesign():
 
 	print("Formatting the file " + designXML + "using the tool XMLlint. The result will be saved in " + tempName)
 	if platform.system() == "Windows":
-		returnCode = subprocess.call("xmllint " + designPath + designXML + " > " + designPath + tempName, shell=True)
+		returnCode = subprocessWithImprovedErrors("xmllint " + designPath + designXML + " > " + designPath + tempName, "xmllint")
 	elif platform.system() == "Linux":
-		returnCode = subprocess.call("xmllint --format " + designPath + designXML + " > " + designPath + tempName, shell=True)
+		returnCode = subprocessWithImprovedErrors("xmllint --format " + designPath + designXML + " > " + designPath + tempName, "xmllint")
 	if returnCode != 0:
 		print("There was a problem Formatting the file " + designXML + "; Return code = " + str(returnCode))
 		return returnCode
@@ -88,15 +88,15 @@ def upgradeDesign(additionalParam):
 	print("Formatting the upgraded file ")
 	formatedOutput = output + ".formatted"
 	if platform.system() == "Windows":
-		returnCode = subprocess.call("xmllint " + designPath + output + " > " + designPath + formatedOutput, shell=True)
+		returnCode = subprocessWithImprovedErrors("xmllint " + designPath + output + " > " + designPath + formatedOutput, "xmllint")
 	elif platform.system() == "Linux":
-		returnCode = subprocess.call("xmllint --format " + designPath + output + " > " + designPath + formatedOutput, shell=True)
+		returnCode = subprocessWithImprovedErrors("xmllint --format " + designPath + output + " > " + designPath + formatedOutput, "xmllint")
 	if returnCode != 0:
 		print("There was a problem formatting the upgraded file; Return code = " + str(returnCode))
 		return returnCode
 		
 	print("Now running merge-tool. Please merge the upgraded changed")
-	returnCode = subprocess.call("kdiff3 -o " + designPath + designXML + " " + designPath + designXML + " " + designPath + formatedOutput, shell=True)
+	returnCode = subprocessWithImprovedErrors("kdiff3 -o " + designPath + designXML + " " + designPath + designXML + " " + designPath + formatedOutput, "kdiff3")
 	if returnCode != 0:
 		print("There was a problem with kdiff3; Return code = " + str(returnCode))
 		return returnCode
@@ -115,7 +115,7 @@ def createDiagram(detailLevel=0):
 	output = "Design.dot"
 	returnCode = transformDesignVerbose(designPath + "designToDot.xslt", designPath + output, 0, 1, "detailLevel=" + str(detailLevel))
 	print("Generating pdf diagram with dot.")
-	returnCode = subprocess.call("dot -Tpdf -o" + designPath + "diagram.pdf " + designPath + "Design.dot", shell=True)
+	returnCode = subprocessWithImprovedErrors("dot -Tpdf -o" + designPath + "diagram.pdf " + designPath + "Design.dot", "GraphViz (dot)")
 	if returnCode != 0:
 		print("There was a problem generating pdf diagram with dot; Return code = " + str(returnCode))
 		return returnCode

--- a/FrameworkInternals/designTools.py
+++ b/FrameworkInternals/designTools.py
@@ -25,6 +25,7 @@ import shutil
 import __main__
 from transformDesign import transformDesignVerbose
 from externalToolCheck import subprocessWithImprovedErrors
+from externalToolCheck import subprocessWithImprovedErrorsPipeOutputToFile
 
 designPath = "Design" + os.path.sep
 designXML = "Design.xml"
@@ -38,7 +39,7 @@ def validateDesign():
 	# This allows some basic checks
 	print("1st line of check -- XSD conformance")
 	print("Validating the file " + designXML + " with the schema " + designXSD)
-	returnCode = subprocessWithImprovedErrors("xmllint --noout --schema " + designPath + designXSD + " " + designPath + designXML, "xmllint")
+	returnCode = subprocessWithImprovedErrors(["xmllint", "--noout", "--schema", designPath + designXSD, designPath + designXML], "xmllint")
 	if returnCode != 0:
 		print("There was a problem validating the file" + designXML + " with the schema " + designXSD + "; Return code = " + str(returnCode))
 		return returnCode
@@ -61,9 +62,9 @@ def formatDesign():
 
 	print("Formatting the file " + designXML + "using the tool XMLlint. The result will be saved in " + tempName)
 	if platform.system() == "Windows":
-		returnCode = subprocessWithImprovedErrors("xmllint " + designPath + designXML + " > " + designPath + tempName, "xmllint")
+		returnCode = subprocessWithImprovedErrorsPipeOutputToFile(["xmllint", designPath + designXML], designPath + tempName, "xmllint")
 	elif platform.system() == "Linux":
-		returnCode = subprocessWithImprovedErrors("xmllint --format " + designPath + designXML + " > " + designPath + tempName, "xmllint")
+		returnCode = subprocessWithImprovedErrorsPipeOutputToFile(["xmllint", "--format", designPath + designXML], designPath + tempName, "xmllint")
 	if returnCode != 0:
 		print("There was a problem Formatting the file " + designXML + "; Return code = " + str(returnCode))
 		return returnCode
@@ -88,15 +89,15 @@ def upgradeDesign(additionalParam):
 	print("Formatting the upgraded file ")
 	formatedOutput = output + ".formatted"
 	if platform.system() == "Windows":
-		returnCode = subprocessWithImprovedErrors("xmllint " + designPath + output + " > " + designPath + formatedOutput, "xmllint")
+		returnCode = subprocessWithImprovedErrorsPipeOutputToFile(["xmllint", designPath + output], designPath + formatedOutput, "xmllint")
 	elif platform.system() == "Linux":
-		returnCode = subprocessWithImprovedErrors("xmllint --format " + designPath + output + " > " + designPath + formatedOutput, "xmllint")
+		returnCode = subprocessWithImprovedErrorsPipeOutputToFile(["xmllint", "--format", designPath + output], designPath + formatedOutput, "xmllint")
 	if returnCode != 0:
 		print("There was a problem formatting the upgraded file; Return code = " + str(returnCode))
 		return returnCode
 		
 	print("Now running merge-tool. Please merge the upgraded changed")
-	returnCode = subprocessWithImprovedErrors("kdiff3 -o " + designPath + designXML + " " + designPath + designXML + " " + designPath + formatedOutput, "kdiff3")
+	returnCode = subprocessWithImprovedErrors(["kdiff3", "-o", designPath + designXML, designPath + designXML, designPath + formatedOutput], "kdiff3")
 	if returnCode != 0:
 		print("There was a problem with kdiff3; Return code = " + str(returnCode))
 		return returnCode
@@ -115,7 +116,7 @@ def createDiagram(detailLevel=0):
 	output = "Design.dot"
 	returnCode = transformDesignVerbose(designPath + "designToDot.xslt", designPath + output, 0, 1, "detailLevel=" + str(detailLevel))
 	print("Generating pdf diagram with dot.")
-	returnCode = subprocessWithImprovedErrors("dot -Tpdf -o" + designPath + "diagram.pdf " + designPath + "Design.dot", "GraphViz (dot)")
+	returnCode = subprocessWithImprovedErrors(["dot", "-Tpdf", "-o", designPath + "diagram.pdf", designPath + "Design.dot"], "GraphViz (dot)")
 	if returnCode != 0:
 		print("There was a problem generating pdf diagram with dot; Return code = " + str(returnCode))
 		return returnCode

--- a/FrameworkInternals/designTools.py
+++ b/FrameworkInternals/designTools.py
@@ -26,6 +26,7 @@ import __main__
 from transformDesign import transformDesignVerbose
 from externalToolCheck import subprocessWithImprovedErrors
 from externalToolCheck import subprocessWithImprovedErrorsPipeOutputToFile
+from commandMap import getCommand
 
 designPath = "Design" + os.path.sep
 designXML = "Design.xml"
@@ -39,7 +40,7 @@ def validateDesign():
 	# This allows some basic checks
 	print("1st line of check -- XSD conformance")
 	print("Validating the file " + designXML + " with the schema " + designXSD)
-	returnCode = subprocessWithImprovedErrors(["xmllint", "--noout", "--schema", designPath + designXSD, designPath + designXML], "xmllint")
+	returnCode = subprocessWithImprovedErrors([getCommand("xmllint"), "--noout", "--schema", designPath + designXSD, designPath + designXML], getCommand("xmllint"))
 	if returnCode != 0:
 		print("There was a problem validating the file" + designXML + " with the schema " + designXSD + "; Return code = " + str(returnCode))
 		return returnCode
@@ -62,9 +63,9 @@ def formatDesign():
 
 	print("Formatting the file " + designXML + "using the tool XMLlint. The result will be saved in " + tempName)
 	if platform.system() == "Windows":
-		returnCode = subprocessWithImprovedErrorsPipeOutputToFile(["xmllint", designPath + designXML], designPath + tempName, "xmllint")
+		returnCode = subprocessWithImprovedErrorsPipeOutputToFile([getCommand("xmllint"), designPath + designXML], designPath + tempName, getCommand("xmllint"))
 	elif platform.system() == "Linux":
-		returnCode = subprocessWithImprovedErrorsPipeOutputToFile(["xmllint", "--format", designPath + designXML], designPath + tempName, "xmllint")
+		returnCode = subprocessWithImprovedErrorsPipeOutputToFile([getCommand("xmllint"), "--format", designPath + designXML], designPath + tempName, getCommand("xmllint"))
 	if returnCode != 0:
 		print("There was a problem Formatting the file " + designXML + "; Return code = " + str(returnCode))
 		return returnCode
@@ -89,15 +90,15 @@ def upgradeDesign(additionalParam):
 	print("Formatting the upgraded file ")
 	formatedOutput = output + ".formatted"
 	if platform.system() == "Windows":
-		returnCode = subprocessWithImprovedErrorsPipeOutputToFile(["xmllint", designPath + output], designPath + formatedOutput, "xmllint")
+		returnCode = subprocessWithImprovedErrorsPipeOutputToFile([getCommand("xmllint"), designPath + output], designPath + formatedOutput, getCommand("xmllint"))
 	elif platform.system() == "Linux":
-		returnCode = subprocessWithImprovedErrorsPipeOutputToFile(["xmllint", "--format", designPath + output], designPath + formatedOutput, "xmllint")
+		returnCode = subprocessWithImprovedErrorsPipeOutputToFile([getCommand("xmllint"), "--format", designPath + output], designPath + formatedOutput, getCommand("xmllint"))
 	if returnCode != 0:
 		print("There was a problem formatting the upgraded file; Return code = " + str(returnCode))
 		return returnCode
 		
 	print("Now running merge-tool. Please merge the upgraded changed")
-	returnCode = subprocessWithImprovedErrors(["kdiff3", "-o", designPath + designXML, designPath + designXML, designPath + formatedOutput], "kdiff3")
+	returnCode = subprocessWithImprovedErrors([getCommand("diff"), "-o", designPath + designXML, designPath + designXML, designPath + formatedOutput], getCommand("diff"))
 	if returnCode != 0:
 		print("There was a problem with kdiff3; Return code = " + str(returnCode))
 		return returnCode
@@ -116,7 +117,7 @@ def createDiagram(detailLevel=0):
 	output = "Design.dot"
 	returnCode = transformDesignVerbose(designPath + "designToDot.xslt", designPath + output, 0, 1, "detailLevel=" + str(detailLevel))
 	print("Generating pdf diagram with dot.")
-	returnCode = subprocessWithImprovedErrors(["dot", "-Tpdf", "-o", designPath + "diagram.pdf", designPath + "Design.dot"], "GraphViz (dot)")
+	returnCode = subprocessWithImprovedErrors([getCommand("graphviz"), "-Tpdf", "-o", designPath + "diagram.pdf", designPath + "Design.dot"], "GraphViz (dot)")
 	if returnCode != 0:
 		print("There was a problem generating pdf diagram with dot; Return code = " + str(returnCode))
 		return returnCode

--- a/FrameworkInternals/deviceGenerators.py
+++ b/FrameworkInternals/deviceGenerators.py
@@ -20,7 +20,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 '''
 
 import os
-import subprocess
 import platform
 import __main__
 from transformDesign import transformDesignVerbose

--- a/FrameworkInternals/distclean.py
+++ b/FrameworkInternals/distclean.py
@@ -21,11 +21,11 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 import os
 import sys
-import subprocess
 import shutil
 import platform
 import __main__
-
+from externalToolCheck import getVcvarsallPath
+from externalToolCheck import subprocessWithImprovedErrors
 
 def deleteFolderRecursively( topdir, target ):
 	for dirpath, dirnames, files in os.walk(topdir):
@@ -66,16 +66,16 @@ def distClean(param=None):
 			print("Calling: python quasar.py clean " + param)
 	if platform.system() == "Windows":
 		print('Calling visual studio vcvarsall to set the environment')
-		print('"C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat" amd64')
-		returnCode = subprocess.call('"C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat" amd64', shell=True)
+		print(getVcvarsallPath() + ' amd64')
+		returnCode = subprocessWithImprovedErrors(getVcvarsallPath() + ' amd64', "visual studio vcvarsall.bat")
 		if returnCode != 0:
 			print('ERROR: vcvarsall could not be executed, maybe the installation folder is different than the one expected? [C:\Program Files (x86)\Microsoft Visual Studio 12.0]')			
 			return returnCode
 		print('Calling msbuild clean')
 		print('msbuild ALL_BUILD.vcxproj /t:Clean')
-		returnCode = subprocess.call('"C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat" amd64 && msbuild ALL_BUILD.vcxproj /t:Clean', shell=True)
+		returnCode = subprocessWithImprovedErrors(getVcvarsallPath() + ' amd64 && msbuild ALL_BUILD.vcxproj /t:Clean', "visual studio msbuild")
 	elif platform.system() == "Linux":
-		returnCode = subprocess.call(['make', 'clean'])
+		returnCode = subprocessWithImprovedErrors(['make', 'clean'], "make")
 	if returnCode != 0:
 		print("There was a problem calling make/msbuild clean; Return code = " + str(returnCode))		
 	print('Deleting generated files and directories')

--- a/FrameworkInternals/distclean.py
+++ b/FrameworkInternals/distclean.py
@@ -24,7 +24,7 @@ import sys
 import shutil
 import platform
 import __main__
-from externalToolCheck import getVcvarsallPath
+from commandMap import getCommand
 from externalToolCheck import subprocessWithImprovedErrors
 
 def deleteFolderRecursively( topdir, target ):
@@ -66,16 +66,16 @@ def distClean(param=None):
 			print("Calling: python quasar.py clean " + param)
 	if platform.system() == "Windows":
 		print('Calling visual studio vcvarsall to set the environment')
-		print(getVcvarsallPath() + ' amd64')
-		returnCode = subprocessWithImprovedErrors(getVcvarsallPath() + ' amd64', "visual studio vcvarsall.bat")
+		print(getCommand("vcvarsall.simple") + ' amd64')
+		returnCode = subprocessWithImprovedErrors(getCommand("vcvarsall") + ' amd64', "visual studio vcvarsall.bat")
 		if returnCode != 0:
-			print('ERROR: vcvarsall could not be executed, maybe the installation folder is different than the one expected? [C:\Program Files (x86)\Microsoft Visual Studio 12.0]')			
+			print('ERROR: vcvarsall could not be executed, maybe the installation folder is different than the one expected? [' + getCommand("vcvarsall.simple") + ']')			
 			return returnCode
 		print('Calling msbuild clean')
 		print('msbuild ALL_BUILD.vcxproj /t:Clean')
-		returnCode = subprocessWithImprovedErrors(getVcvarsallPath() + ' amd64 && msbuild ALL_BUILD.vcxproj /t:Clean', "visual studio msbuild")
+		returnCode = subprocessWithImprovedErrors(getCommand("vcvarsall") + ' amd64 && msbuild ALL_BUILD.vcxproj /t:Clean', "visual studio msbuild")
 	elif platform.system() == "Linux":
-		returnCode = subprocessWithImprovedErrors(['make', 'clean'], "make")
+		returnCode = subprocessWithImprovedErrors([getCommand('make'), 'clean'], getCommand("make"))
 	if returnCode != 0:
 		print("There was a problem calling make/msbuild clean; Return code = " + str(returnCode))		
 	print('Deleting generated files and directories')

--- a/FrameworkInternals/externalToolCheck.py
+++ b/FrameworkInternals/externalToolCheck.py
@@ -26,19 +26,20 @@ import subprocess
 from subprocess import Popen
 import filecmp
 import __main__
+from commandMap import getCommand
 
 VERBOSE = 1
-XSLT_JAR = '.' + os.path.sep + 'Design' + os.path.sep + 'saxon9he.jar'
+XSLT_JAR = '.' + os.path.sep + 'Design' + os.path.sep + getCommand('saxon')
 
-def getVcvarsallPath(simpleQuotes=False):
-	"""
-	Method that returns the absolute path of vcvarsall.bat. Since this is hardcoded at the moment, and used trough different parts of the scripts, at least is hardcoded only once
-	It is returned in double quotation marks, because it needs to be used with quotes inside of the string, because of the spaces on the path
-	"""
-	if(simpleQuotes):
-		return "C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat"
-	else:
-		return '"C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat"'
+#def getVcvarsallPath(simpleQuotes=False):
+#	"""
+#	Method that returns the absolute path of vcvarsall.bat. Since this is hardcoded at the moment, and used trough different parts of the scripts, at least is hardcoded only once
+#	It is returned in double quotation marks, because it needs to be used with quotes inside of the string, because of the spaces on the path
+#	"""
+#	if(simpleQuotes):
+#		return "C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat"
+#	else:
+#		return '"C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat"'
 
 def printIfVerbose(msg):
 	if VERBOSE > 0:
@@ -46,7 +47,7 @@ def printIfVerbose(msg):
 
 def checkJava():
 	try:
-		returnCode = subprocess.call(['java', '-h'], stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
+		returnCode = subprocess.call([getCommand('java'), '-h'], stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
 		if returnCode == 0:
 			printIfVerbose("Java does exist")
 		else:
@@ -62,7 +63,7 @@ def checkSaxon():
 	
 def checkAstyle():
 	try:
-		returnCode = subprocess.call(['astyle', '-h'], stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
+		returnCode = subprocess.call([getCommand('astyle'), '-h'], stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
 		if returnCode == 0:
 			printIfVerbose("astyle does exist")
 		else:
@@ -74,9 +75,9 @@ def checkKdiff3():
 	try:
 		returnCode = -1
 		if platform.system() == "Windows":
-			returnCode = subprocess.call(['where', 'kdiff3'], stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
+			returnCode = subprocess.call(['where', getCommand('diff')], stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
 		else:
-			returnCode = subprocess.call(['kdiff3', '--help'], stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
+			returnCode = subprocess.call([getCommand('diff'), '--help'], stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
 		if returnCode == 0:
 			printIfVerbose("kdiff3 does exist")
 		else:
@@ -86,7 +87,7 @@ def checkKdiff3():
 
 def checkCMake():
 	try:
-		returnCode = subprocess.call(['cmake', '-h'], stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
+		returnCode = subprocess.call([getCommand('cmake'), '-h'], stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
 		if returnCode == 0:
 			printIfVerbose("CMake does exist")
 		else:
@@ -96,12 +97,12 @@ def checkCMake():
 		
 def checkCompiler():
 	if platform.system() == "Windows":
-		if os.path.isfile(getVcvarsallPath(True)):
+		if os.path.isfile(getCommand('vcvarsall.simple')):
 			printIfVerbose("vcvarsall.bat does exist")
 		else:		
-			raise Exception("vcvarsall.bat cannot be found in the default path [" + getVcvarsallPath(True) + "]. Maybe Visual Studio 2013 is not installed, or there is a problem with your installation. ")
+			raise Exception("vcvarsall.bat cannot be found in the default path [" + getCommand('vcvarsall.simple') + "]. Maybe Visual Studio 2013 is not installed, or there is a problem with your installation. ")
 		try:
-			returnCode = subprocess.call(getVcvarsallPath() + ' amd64 && msbuild /h', shell=True, stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
+			returnCode = subprocess.call(getCommand('vcvarsall') + ' amd64 && ' + getCommand('msbuild') + ' /h', shell=True, stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
 			if returnCode == 0:
 				printIfVerbose("msbuild does exist")
 			else:
@@ -111,7 +112,7 @@ def checkCompiler():
 		
 	elif platform.system() == "Linux":
 		try:
-			returnCode = subprocess.call(['make', '-h'], stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
+			returnCode = subprocess.call([getCommand('make'), '-h'], stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
 			if returnCode == 0:
 				printIfVerbose("make does exist")
 			else:
@@ -121,7 +122,7 @@ def checkCompiler():
 			
 def checkXMLLint():
 	try:
-		returnCode = subprocess.call(['xmllint', '--version'], stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
+		returnCode = subprocess.call([getCommand('xmllint'), '--version'], stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
 		if returnCode == 0:
 			printIfVerbose("XML Lint does exist")
 		else:
@@ -132,7 +133,7 @@ def checkXMLLint():
 #Non compulsory dependancy (Needed for generating graphs, but QUASAR will perfectly work without GraphViz)
 def checkGraphViz():
 	try:
-		returnCode = subprocess.call(['dot', '-V'], stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
+		returnCode = subprocess.call([getCommand('graphviz'), '-V'], stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
 		if returnCode == 0:
 			printIfVerbose("GraphViz does exist")
 		else:
@@ -145,9 +146,9 @@ def checkDoxyGen():
 	try:
 		returnCode = -1
 		if platform.system() == "Windows":
-			returnCode = subprocess.call(['where', 'doxygen'], stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
+			returnCode = subprocess.call(['where', getCommand('doxygen')], stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
 		else:
-			returnCode = subprocess.call(['which', 'doxygen'], stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
+			returnCode = subprocess.call(['which', getCommand('doxygen')], stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
 		if returnCode == 0:
 			printIfVerbose("DoxyGen does exist")
 		else:
@@ -155,46 +156,28 @@ def checkDoxyGen():
 	except:
 		raise Exception("DoxyGen cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nDoxyGen can be downloaded in http://www.stack.nl/~dimitri/doxygen/ ")
 	
+def tryDependency(functionCheck, critical=True):
+	try:
+		functionCheck()
+	except Exception, e:
+		if(critical):
+			print("CRITICAL dependency missing: " + str(e))
+		else:
+			print("Optional dependency missing: " + str(e))
+
 def checkExternalDependencies():
 	"""Checks all of QUASAR dependencies to see if everything is setup as expected, and prints apropiate messages to point out what is missing."""
 	if "quasarGUI.py" in __main__.__file__:
 		print("Calling: python quasar.py dependency_check")
-	try:
-		checkSaxon()
-	except Exception, e:
-		print("CRITICAL dependency missing: " + str(e))
-	try:
-		checkJava()
-	except Exception, e:
-		print("CRITICAL dependency missing: " + str(e))	
-	try:
-		checkKdiff3()
-	except Exception, e:
-		print("CRITICAL dependency missing: " + str(e))
-	try:
-		checkCMake()
-	except Exception, e:
-		print("CRITICAL dependency missing: " + str(e))
-	try:
-		checkCompiler()
-	except Exception, e:
-		print("CRITICAL dependency missing: " + str(e))
-	try:
-		checkXMLLint()
-	except Exception, e:
-		print("CRITICAL dependency missing: " + str(e))
-	try:
-		checkAstyle()
-	except Exception, e:
-		print("Optional dependency missing: " + str(e))
-	try:
-		checkGraphViz()
-	except Exception, e:
-		print("Optional dependency missing: " + str(e))
-	try:
-		checkDoxyGen()
-	except Exception, e:
-		print("Optional dependency missing: " + str(e))
+	tryDependency(checkSaxon)
+	tryDependency(checkJava)
+	tryDependency(checkKdiff3)
+	tryDependency(checkCMake)
+	tryDependency(checkCompiler)
+	tryDependency(checkXMLLint)
+	tryDependency(checkAstyle, False)
+	tryDependency(checkGraphViz, False)
+	tryDependency(checkDoxyGen, False)
 		
 def subprocessWithImprovedErrors(subprocessCommand, dependencyName):
 	"""Method that calls subprocess, but print intelligent error messages if there are any exceptions catched.

--- a/FrameworkInternals/externalToolCheck.py
+++ b/FrameworkInternals/externalToolCheck.py
@@ -202,8 +202,8 @@ def subprocessWithImprovedErrors(subprocessCommand, dependencyName):
 	try:
 		return subprocess.call(subprocessCommand)
 	except OSError as e:		
-		print("There was an OS error when trying to execute the program [" + dependencyName + "]. Probably it is missing or non-accesible; Exception: [" + str(e) + "]. For more details run the command 'quasar.py dependency_check'.")
-		raise Exception("There was an OS error when trying to execute the program [" + dependencyName + "]. Probably it is missing or non-accesible; Exception: [" + str(e) + "]")
+		#print("There was an OS error when trying to execute the program [" + dependencyName + "]. This probably means that a dependancy is missing or non-accesible; Exception: [" + str(e) + "]. For more details run the command 'quasar.py dependency_check'.")
+		raise Exception("There was an OS error when trying to execute the program [" + dependencyName + "]. This probably means that a dependancy is missing or non-accesible; Exception: [" + str(e) + "]. For more details run the command 'quasar.py dependency_check'.")
 	except Exception, e:
-		print("There was an application error when trying to execute the program [" + dependencyName + "]. Exception: [" + str(e) + "].")
+		#print("There was an application error when trying to execute the program [" + dependencyName + "]. Exception: [" + str(e) + "].")
 		raise Exception("There was an application error when trying to execute the program [" + dependencyName + "]. Exception: [" + str(e) + "]")

--- a/FrameworkInternals/externalToolCheck.py
+++ b/FrameworkInternals/externalToolCheck.py
@@ -24,11 +24,20 @@ import platform
 import sys
 import subprocess
 import filecmp
-import time
 
-VERBOSE = 0
+VERBOSE = 1
 XSLT_JAR = '.' + os.path.sep + 'Design' + os.path.sep + 'saxon9he.jar'
-VCVARSALL = "C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat"
+
+def getVcvarsallPath(simpleQuotes=False):
+	"""
+	Method that returns the absolute path of vcvarsall.bat. Since this is hardcoded at the moment, and used trough different parts of the scripts, at least is hardcoded only once
+	It is returned in double quotation marks, because it needs to be used with quotes inside of the string, because of the spaces on the path
+	"""
+	if(simpleQuotes):
+		return "C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat"
+	else:
+		return '"C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat"'
+
 def printIfVerbose(msg):
 	if VERBOSE > 0:
 		print(msg)
@@ -39,15 +48,15 @@ def checkJava():
 		if returnCode == 0:
 			printIfVerbose("Java does exist")
 		else:
-			raise Exception("Java cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nJava can be downloaded in https://www.java.com/en/download/ \nThe script will stop now.")
+			raise Exception("Java cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nJava can be downloaded in https://www.java.com/en/download/ ")
 	except:
-		raise Exception("Java cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nJava can be downloaded in https://www.java.com/en/download/ \nThe script will stop now.")
+		raise Exception("Java cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nJava can be downloaded in https://www.java.com/en/download/ ")
 	
 def checkSaxon():
 	if os.path.isfile(XSLT_JAR):
 		printIfVerbose("jaxon0he.jar does exist")
 	else:
-		raise Exception("jaxon0he.jar cannot be found in the Design folder. \njaxon0he.jar can be downloaded in http://saxon.sourceforge.net/#F9.7HE \nThe script will stop now.")
+		raise Exception("jaxon0he.jar cannot be found in the Design folder. \njaxon0he.jar can be downloaded in http://saxon.sourceforge.net/#F9.7HE ")
 	
 def checkAstyle():
 	try:
@@ -55,9 +64,9 @@ def checkAstyle():
 		if returnCode == 0:
 			printIfVerbose("astyle does exist")
 		else:
-			raise Exception("Astyle cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nAstyle can be downloaded in http://astyle.sourceforge.net/ \nThe script will stop now.")
+			raise Exception("Astyle cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nAstyle can be downloaded in http://astyle.sourceforge.net/ ")
 	except:
-		raise Exception("Astyle cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nAstyle can be downloaded in http://astyle.sourceforge.net/ \nThe script will stop now.")
+		raise Exception("Astyle cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nAstyle can be downloaded in http://astyle.sourceforge.net/ ")
 	
 def checkKdiff3():
 	try:
@@ -69,9 +78,9 @@ def checkKdiff3():
 		if returnCode == 0:
 			printIfVerbose("kdiff3 does exist")
 		else:
-			raise Exception("kdiff3 cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nkdiff3 can be downloaded in http://kdiff3.sourceforge.net/ \nThe script will stop now.")
+			raise Exception("kdiff3 cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nkdiff3 can be downloaded in http://kdiff3.sourceforge.net/ ")
 	except:
-		raise Exception("kdiff3 cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nkdiff3 can be downloaded in http://kdiff3.sourceforge.net/ \nThe script will stop now.")
+		raise Exception("kdiff3 cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nkdiff3 can be downloaded in http://kdiff3.sourceforge.net/ ")
 
 def checkCMake():
 	try:
@@ -79,24 +88,24 @@ def checkCMake():
 		if returnCode == 0:
 			printIfVerbose("CMake does exist")
 		else:
-			raise Exception("CMake cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nCMake can be downloaded in https://cmake.org/ \nThe script will stop now.")
+			raise Exception("CMake cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nCMake can be downloaded in https://cmake.org/ ")
 	except:
-		raise Exception("CMake cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nCMake can be downloaded in https://cmake.org/ \nThe script will stop now.")
+		raise Exception("CMake cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nCMake can be downloaded in https://cmake.org/ ")
 		
 def checkCompiler():
 	if platform.system() == "Windows":
-		if os.path.isfile(VCVARSALL):
+		if os.path.isfile(getVcvarsallPath(True)):
 			printIfVerbose("vcvarsall.bat does exist")
 		else:		
-			raise Exception("vcvarsall.bat cannot be found in the default path [" + VCVARSALL + "]. Maybe Visual Studio 2013 is not installed, or there is a problem with your installation. \nThe script will stop now.")
+			raise Exception("vcvarsall.bat cannot be found in the default path [" + getVcvarsallPath(True) + "]. Maybe Visual Studio 2013 is not installed, or there is a problem with your installation. ")
 		try:
-			returnCode = subprocess.call('"C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat" amd64 && msbuild /h', shell=True, stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
+			returnCode = subprocess.call(getVcvarsallPath() + ' amd64 && msbuild /h', shell=True, stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
 			if returnCode == 0:
 				printIfVerbose("msbuild does exist")
 			else:
-				raise Exception("msbuild cannot be properly executed after calling vcvarsall.bat . Maybe Visual Studio 2013 is not installed, or there is a problem with your installation. \nThe script will stop now.")
+				raise Exception("msbuild cannot be properly executed after calling vcvarsall.bat . Maybe Visual Studio 2013 is not installed, or there is a problem with your installation. ")
 		except:
-			raise Exception("msbuild cannot be properly executed after calling vcvarsall.bat . Maybe Visual Studio 2013 is not installed, or there is a problem with your installation. \nThe script will stop now.")
+			raise Exception("msbuild cannot be properly executed after calling vcvarsall.bat . Maybe Visual Studio 2013 is not installed, or there is a problem with your installation. ")
 		
 	elif platform.system() == "Linux":
 		try:
@@ -104,9 +113,9 @@ def checkCompiler():
 			if returnCode == 0:
 				printIfVerbose("make does exist")
 			else:
-				raise Exception("make cannot be found. Maybe it is not installed, or maybe it is not set in the PATH.\nThe script will stop now.")
+				raise Exception("make cannot be found. Maybe it is not installed, or maybe it is not set in the PATH.")
 		except:
-			raise Exception("make cannot be found. Maybe it is not installed, or maybe it is not set in the PATH.\nThe script will stop now.")
+			raise Exception("make cannot be found. Maybe it is not installed, or maybe it is not set in the PATH.")
 			
 def checkXMLLint():
 	try:
@@ -114,9 +123,9 @@ def checkXMLLint():
 		if returnCode == 0:
 			printIfVerbose("XML Lint does exist")
 		else:
-			raise Exception("XML Lint cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nXML Lint can be downloaded in http://xmlsoft.org/ \nThe script will stop now.")
+			raise Exception("XML Lint cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nXML Lint can be downloaded in http://xmlsoft.org/ ")
 	except:
-		raise Exception("XML Lint cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nXML Lint can be downloaded in http://xmlsoft.org/ \nThe script will stop now.")
+		raise Exception("XML Lint cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nXML Lint can be downloaded in http://xmlsoft.org/ ")
 
 #Non compulsory dependancy (Needed for generating graphs, but QUASAR will perfectly work without GraphViz)
 def checkGraphViz():
@@ -125,9 +134,9 @@ def checkGraphViz():
 		if returnCode == 0:
 			printIfVerbose("GraphViz does exist")
 		else:
-			raise Exception("GraphViz cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nGraphViz can be downloaded in http://www.graphviz.org/ \nThe script will stop now.")
+			raise Exception("GraphViz cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nGraphViz can be downloaded in http://www.graphviz.org/ ")
 	except:
-		raise Exception("GraphViz cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nGraphViz can be downloaded in http://www.graphviz.org/ \nThe script will stop now.")
+		raise Exception("GraphViz cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nGraphViz can be downloaded in http://www.graphviz.org/ ")
 
 #Non compulsory dependancy (Needed for generating documentation, but QUASAR will perfectly work without DoxyGen)
 def checkDoxyGen():
@@ -140,21 +149,61 @@ def checkDoxyGen():
 		if returnCode == 0:
 			printIfVerbose("DoxyGen does exist")
 		else:
-			raise Exception("DoxyGen cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nDoxyGen can be downloaded in http://www.stack.nl/~dimitri/doxygen/ \nThe script will stop now.")
+			raise Exception("DoxyGen cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nDoxyGen can be downloaded in http://www.stack.nl/~dimitri/doxygen/ ")
 	except:
-		raise Exception("DoxyGen cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nDoxyGen can be downloaded in http://www.stack.nl/~dimitri/doxygen/ \nThe script will stop now.")
+		raise Exception("DoxyGen cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nDoxyGen can be downloaded in http://www.stack.nl/~dimitri/doxygen/ ")
 	
-def checkExternalDependancies(usingGraphViz, usingDoxyGen):
-	start_time = time.time()
-	checkSaxon()
-	checkJava()
-	checkAstyle()
-	checkKdiff3()
-	checkCMake()
-	checkCompiler()
-	checkXMLLint()
-	if usingGraphViz:
+def checkExternalDependencies():
+	"""Checks all of QUASAR dependencies to see if everything is setup as expected, and prints apropiate messages to point out what is missing."""
+	try:
+		checkSaxon()
+	except Exception, e:
+		print("CRITICAL dependency missing: " + str(e))
+	try:
+		checkJava()
+	except Exception, e:
+		print("CRITICAL dependency missing: " + str(e))
+	try:
+		checkAstyle()
+	except Exception, e:
+		print("CRITICAL dependency missing: " + str(e))
+	try:
+		checkKdiff3()
+	except Exception, e:
+		print("CRITICAL dependency missing: " + str(e))
+	try:
+		checkCMake()
+	except Exception, e:
+		print("CRITICAL dependency missing: " + str(e))
+	try:
+		checkCompiler()
+	except Exception, e:
+		print("CRITICAL dependency missing: " + str(e))
+	try:
+		checkXMLLint()
+	except Exception, e:
+		print("CRITICAL dependency missing: " + str(e))
+	try:
 		checkGraphViz()
-	if usingDoxyGen:
+	except Exception, e:
+		print("Optional dependency missing: " + str(e))
+	try:
 		checkDoxyGen()
-	printIfVerbose('check completed in [' + str(time.time()-start_time) + '] seconds')
+	except Exception, e:
+		print("Optional dependency missing: " + str(e))
+		
+def subprocessWithImprovedErrors(subprocessCommand, dependencyName):
+	"""Method that calls subprocess, but print intelligent error messages if there are any exceptions catched.
+	
+	Keyword arguments:
+	subprocessCommand -- String or list of strings that will be given to subprocess
+	dependencyName -- parameterless name of the command, just for error loging purposes
+	"""	
+	try:
+		return subprocess.call(subprocessCommand)
+	except OSError as e:		
+		print("There was an OS error when trying to execute the program [" + dependencyName + "]. Probably it is missing or non-accesible; Exception: [" + str(e) + "]. For more details run the command 'quasar.py dependency_check'.")
+		raise Exception("There was an OS error when trying to execute the program [" + dependencyName + "]. Probably it is missing or non-accesible; Exception: [" + str(e) + "]")
+	except Exception, e:
+		print("There was an application error when trying to execute the program [" + dependencyName + "]. Exception: [" + str(e) + "].")
+		raise Exception("There was an application error when trying to execute the program [" + dependencyName + "]. Exception: [" + str(e) + "]")

--- a/FrameworkInternals/externalToolCheck.py
+++ b/FrameworkInternals/externalToolCheck.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python
+# encoding: utf-8
+'''
+externalToolCheck.py
+
+@author:     Damian Abalo Miron <damian.abalo@cern.ch>
+
+@copyright:  2016 CERN
+
+@license:
+Copyright (c) 2016, CERN, Universidad de Oviedo.
+All rights reserved.
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+@contact:    damian.abalo@cern.ch
+'''
+
+import os
+import os.path
+import platform
+import sys
+import subprocess
+import filecmp
+import time
+
+VERBOSE = 0
+XSLT_JAR = '.' + os.path.sep + 'Design' + os.path.sep + 'saxon9he.jar'
+VCVARSALL = "C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat"
+def printIfVerbose(msg):
+	if VERBOSE > 0:
+		print(msg)
+
+def checkJava():
+	try:
+		returnCode = subprocess.call(['java', '-h'], stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
+		if returnCode == 0:
+			printIfVerbose("Java does exist")
+		else:
+			raise Exception("Java cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nJava can be downloaded in https://www.java.com/en/download/ \nThe script will stop now.")
+	except:
+		raise Exception("Java cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nJava can be downloaded in https://www.java.com/en/download/ \nThe script will stop now.")
+	
+def checkSaxon():
+	if os.path.isfile(XSLT_JAR):
+		printIfVerbose("jaxon0he.jar does exist")
+	else:
+		raise Exception("jaxon0he.jar cannot be found in the Design folder. \njaxon0he.jar can be downloaded in http://saxon.sourceforge.net/#F9.7HE \nThe script will stop now.")
+	
+def checkAstyle():
+	try:
+		returnCode = subprocess.call(['astyle', '-h'], stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
+		if returnCode == 0:
+			printIfVerbose("astyle does exist")
+		else:
+			raise Exception("Astyle cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nAstyle can be downloaded in http://astyle.sourceforge.net/ \nThe script will stop now.")
+	except:
+		raise Exception("Astyle cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nAstyle can be downloaded in http://astyle.sourceforge.net/ \nThe script will stop now.")
+	
+def checkKdiff3():
+	try:
+		returnCode = -1
+		if platform.system() == "Windows":
+			returnCode = subprocess.call(['where', 'kdiff3'], stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
+		else:
+			returnCode = subprocess.call(['kdiff3', '--help'], stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
+		if returnCode == 0:
+			printIfVerbose("kdiff3 does exist")
+		else:
+			raise Exception("kdiff3 cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nkdiff3 can be downloaded in http://kdiff3.sourceforge.net/ \nThe script will stop now.")
+	except:
+		raise Exception("kdiff3 cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nkdiff3 can be downloaded in http://kdiff3.sourceforge.net/ \nThe script will stop now.")
+
+def checkCMake():
+	try:
+		returnCode = subprocess.call(['cmake', '-h'], stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
+		if returnCode == 0:
+			printIfVerbose("CMake does exist")
+		else:
+			raise Exception("CMake cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nCMake can be downloaded in https://cmake.org/ \nThe script will stop now.")
+	except:
+		raise Exception("CMake cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nCMake can be downloaded in https://cmake.org/ \nThe script will stop now.")
+		
+def checkCompiler():
+	if platform.system() == "Windows":
+		if os.path.isfile(VCVARSALL):
+			printIfVerbose("vcvarsall.bat does exist")
+		else:		
+			raise Exception("vcvarsall.bat cannot be found in the default path [" + VCVARSALL + "]. Maybe Visual Studio 2013 is not installed, or there is a problem with your installation. \nThe script will stop now.")
+		try:
+			returnCode = subprocess.call('"C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat" amd64 && msbuild /h', shell=True, stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
+			if returnCode == 0:
+				printIfVerbose("msbuild does exist")
+			else:
+				raise Exception("msbuild cannot be properly executed after calling vcvarsall.bat . Maybe Visual Studio 2013 is not installed, or there is a problem with your installation. \nThe script will stop now.")
+		except:
+			raise Exception("msbuild cannot be properly executed after calling vcvarsall.bat . Maybe Visual Studio 2013 is not installed, or there is a problem with your installation. \nThe script will stop now.")
+		
+	elif platform.system() == "Linux":
+		try:
+			returnCode = subprocess.call(['make', '-h'], stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
+			if returnCode == 0:
+				printIfVerbose("make does exist")
+			else:
+				raise Exception("make cannot be found. Maybe it is not installed, or maybe it is not set in the PATH.\nThe script will stop now.")
+		except:
+			raise Exception("make cannot be found. Maybe it is not installed, or maybe it is not set in the PATH.\nThe script will stop now.")
+			
+def checkXMLLint():
+	try:
+		returnCode = subprocess.call(['xmllint', '--version'], stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
+		if returnCode == 0:
+			printIfVerbose("XML Lint does exist")
+		else:
+			raise Exception("XML Lint cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nXML Lint can be downloaded in http://xmlsoft.org/ \nThe script will stop now.")
+	except:
+		raise Exception("XML Lint cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nXML Lint can be downloaded in http://xmlsoft.org/ \nThe script will stop now.")
+
+#Non compulsory dependancy (Needed for generating graphs, but QUASAR will perfectly work without GraphViz)
+def checkGraphViz():
+	try:
+		returnCode = subprocess.call(['dot', '-V'], stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
+		if returnCode == 0:
+			printIfVerbose("GraphViz does exist")
+		else:
+			raise Exception("GraphViz cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nGraphViz can be downloaded in http://www.graphviz.org/ \nThe script will stop now.")
+	except:
+		raise Exception("GraphViz cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nGraphViz can be downloaded in http://www.graphviz.org/ \nThe script will stop now.")
+
+#Non compulsory dependancy (Needed for generating documentation, but QUASAR will perfectly work without DoxyGen)
+def checkDoxyGen():
+	try:
+		returnCode = -1
+		if platform.system() == "Windows":
+			returnCode = subprocess.call(['where', 'doxygen'], stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
+		else:
+			returnCode = subprocess.call(['which', 'doxygen'], stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
+		if returnCode == 0:
+			printIfVerbose("DoxyGen does exist")
+		else:
+			raise Exception("DoxyGen cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nDoxyGen can be downloaded in http://www.stack.nl/~dimitri/doxygen/ \nThe script will stop now.")
+	except:
+		raise Exception("DoxyGen cannot be found. Maybe it is not installed, or maybe it is not set in the PATH. \nDoxyGen can be downloaded in http://www.stack.nl/~dimitri/doxygen/ \nThe script will stop now.")
+	
+def checkExternalDependancies(usingGraphViz, usingDoxyGen):
+	start_time = time.time()
+	checkSaxon()
+	checkJava()
+	checkAstyle()
+	checkKdiff3()
+	checkCMake()
+	checkCompiler()
+	checkXMLLint()
+	if usingGraphViz:
+		checkGraphViz()
+	if usingDoxyGen:
+		checkDoxyGen()
+	printIfVerbose('check completed in [' + str(time.time()-start_time) + '] seconds')

--- a/FrameworkInternals/externalToolCheck.py
+++ b/FrameworkInternals/externalToolCheck.py
@@ -155,6 +155,8 @@ def checkDoxyGen():
 	
 def checkExternalDependencies():
 	"""Checks all of QUASAR dependencies to see if everything is setup as expected, and prints apropiate messages to point out what is missing."""
+	if "quasarGUI.py" in __main__.__file__:
+		print("Calling: python quasar.py dependency_check")
 	try:
 		checkSaxon()
 	except Exception, e:

--- a/FrameworkInternals/externalToolCheck.py
+++ b/FrameworkInternals/externalToolCheck.py
@@ -24,6 +24,7 @@ import platform
 import sys
 import subprocess
 import filecmp
+import __main__
 
 VERBOSE = 1
 XSLT_JAR = '.' + os.path.sep + 'Design' + os.path.sep + 'saxon9he.jar'

--- a/FrameworkInternals/externalToolCheck.py
+++ b/FrameworkInternals/externalToolCheck.py
@@ -23,6 +23,7 @@ import os.path
 import platform
 import sys
 import subprocess
+from subprocess import Popen
 import filecmp
 import __main__
 
@@ -165,11 +166,7 @@ def checkExternalDependencies():
 	try:
 		checkJava()
 	except Exception, e:
-		print("CRITICAL dependency missing: " + str(e))
-	try:
-		checkAstyle()
-	except Exception, e:
-		print("CRITICAL dependency missing: " + str(e))
+		print("CRITICAL dependency missing: " + str(e))	
 	try:
 		checkKdiff3()
 	except Exception, e:
@@ -186,6 +183,10 @@ def checkExternalDependencies():
 		checkXMLLint()
 	except Exception, e:
 		print("CRITICAL dependency missing: " + str(e))
+	try:
+		checkAstyle()
+	except Exception, e:
+		print("Optional dependency missing: " + str(e))
 	try:
 		checkGraphViz()
 	except Exception, e:
@@ -204,6 +205,26 @@ def subprocessWithImprovedErrors(subprocessCommand, dependencyName):
 	"""	
 	try:
 		return subprocess.call(subprocessCommand)
+	except OSError as e:		
+		#print("There was an OS error when trying to execute the program [" + dependencyName + "]. This probably means that a dependancy is missing or non-accesible; Exception: [" + str(e) + "]. For more details run the command 'quasar.py dependency_check'.")
+		raise Exception("There was an OS error when trying to execute the program [" + dependencyName + "]. This probably means that a dependancy is missing or non-accesible; Exception: [" + str(e) + "]. For more details run the command 'quasar.py dependency_check'.")
+	except Exception, e:
+		#print("There was an application error when trying to execute the program [" + dependencyName + "]. Exception: [" + str(e) + "].")
+		raise Exception("There was an application error when trying to execute the program [" + dependencyName + "]. Exception: [" + str(e) + "]")
+
+def subprocessWithImprovedErrorsPipeOutputToFile(subprocessCommand, outputFile, dependencyName):
+	"""Method that calls subprocess, but print intelligent error messages if there are any exceptions catched, and then pipes the output of the process to the given file
+	
+	Keyword arguments:
+	subprocessCommand -- String or list of strings that will be given to subprocess
+	dependencyName -- parameterless name of the command, just for error loging purposes
+	outputFile -- file where the std out of the process will be written into
+	"""	
+	try:
+		with open(outputFile,"wb") as out:
+			process = subprocess.Popen(subprocessCommand, stdout=out)
+			streamdata = process.communicate()
+			return process.returncode
 	except OSError as e:		
 		#print("There was an OS error when trying to execute the program [" + dependencyName + "]. This probably means that a dependancy is missing or non-accesible; Exception: [" + str(e) + "]. For more details run the command 'quasar.py dependency_check'.")
 		raise Exception("There was an OS error when trying to execute the program [" + dependencyName + "]. This probably means that a dependancy is missing or non-accesible; Exception: [" + str(e) + "]. For more details run the command 'quasar.py dependency_check'.")

--- a/FrameworkInternals/generateCmake.py
+++ b/FrameworkInternals/generateCmake.py
@@ -21,9 +21,9 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 import os
 import sys
-import subprocess
 import platform
 from transformDesign import transformDesignVerbose
+from externalToolCheck import subprocessWithImprovedErrors
 
 def generateCmake(BUILD_TYPE="Release", CMAKE_TOOLCHAIN_FILE="default_configuration.cmake"):
 	"""Generates CMake header lists in various directories, and then calls cmake.
@@ -37,9 +37,9 @@ def generateCmake(BUILD_TYPE="Release", CMAKE_TOOLCHAIN_FILE="default_configurat
 
 	print("Calling CMake")
 	if platform.system() == "Windows":
-		returnCode = subprocess.call("cmake -DCMAKE_BUILD_TYPE=" + BUILD_TYPE + " -DCMAKE_TOOLCHAIN_FILE=" + CMAKE_TOOLCHAIN_FILE + " -G \"Visual Studio 12 Win64\" .", shell=True)
+		returnCode = subprocessWithImprovedErrors("cmake -DCMAKE_BUILD_TYPE=" + BUILD_TYPE + " -DCMAKE_TOOLCHAIN_FILE=" + CMAKE_TOOLCHAIN_FILE + " -G \"Visual Studio 12 Win64\" .", "cmake")
 	elif platform.system() == "Linux":
-		returnCode = subprocess.call("cmake -DCMAKE_BUILD_TYPE=" + BUILD_TYPE + " -DCMAKE_TOOLCHAIN_FILE=" + CMAKE_TOOLCHAIN_FILE + " .", shell=True)
+		returnCode = subprocessWithImprovedErrors("cmake -DCMAKE_BUILD_TYPE=" + BUILD_TYPE + " -DCMAKE_TOOLCHAIN_FILE=" + CMAKE_TOOLCHAIN_FILE + " .", "cmake")
 	if returnCode != 0:
 		print("There was a problem calling cmake; Return code = " + str(returnCode))
 		return returnCode

--- a/FrameworkInternals/generateCmake.py
+++ b/FrameworkInternals/generateCmake.py
@@ -24,6 +24,7 @@ import sys
 import platform
 from transformDesign import transformDesignVerbose
 from externalToolCheck import subprocessWithImprovedErrors
+from commandMap import getCommand
 
 def generateCmake(BUILD_TYPE="Release", CMAKE_TOOLCHAIN_FILE="default_configuration.cmake"):
 	"""Generates CMake header lists in various directories, and then calls cmake.
@@ -37,9 +38,9 @@ def generateCmake(BUILD_TYPE="Release", CMAKE_TOOLCHAIN_FILE="default_configurat
 
 	print("Calling CMake")
 	if platform.system() == "Windows":
-		returnCode = subprocessWithImprovedErrors("cmake -DCMAKE_BUILD_TYPE=" + BUILD_TYPE + " -DCMAKE_TOOLCHAIN_FILE=" + CMAKE_TOOLCHAIN_FILE + " -G \"Visual Studio 12 Win64\" .", "cmake")
+		returnCode = subprocessWithImprovedErrors([getCommand("cmake"), "-DCMAKE_BUILD_TYPE=" + BUILD_TYPE, "-DCMAKE_TOOLCHAIN_FILE=" + CMAKE_TOOLCHAIN_FILE,"-G", "Visual Studio 12 2013 Win64", "."], getCommand("cmake"))
 	elif platform.system() == "Linux":
-		returnCode = subprocessWithImprovedErrors(["cmake", "-DCMAKE_BUILD_TYPE=" + BUILD_TYPE, "-DCMAKE_TOOLCHAIN_FILE=" + CMAKE_TOOLCHAIN_FILE,"."], "cmake")
+		returnCode = subprocessWithImprovedErrors([getCommand("cmake"), "-DCMAKE_BUILD_TYPE=" + BUILD_TYPE, "-DCMAKE_TOOLCHAIN_FILE=" + CMAKE_TOOLCHAIN_FILE,"."], getCommand("cmake"))
 	if returnCode != 0:
 		print("There was a problem calling cmake; Return code = " + str(returnCode))
 		return returnCode

--- a/FrameworkInternals/generateCmake.py
+++ b/FrameworkInternals/generateCmake.py
@@ -39,7 +39,7 @@ def generateCmake(BUILD_TYPE="Release", CMAKE_TOOLCHAIN_FILE="default_configurat
 	if platform.system() == "Windows":
 		returnCode = subprocessWithImprovedErrors("cmake -DCMAKE_BUILD_TYPE=" + BUILD_TYPE + " -DCMAKE_TOOLCHAIN_FILE=" + CMAKE_TOOLCHAIN_FILE + " -G \"Visual Studio 12 Win64\" .", "cmake")
 	elif platform.system() == "Linux":
-		returnCode = subprocessWithImprovedErrors("cmake -DCMAKE_BUILD_TYPE=" + BUILD_TYPE + " -DCMAKE_TOOLCHAIN_FILE=" + CMAKE_TOOLCHAIN_FILE + " .", "cmake")
+		returnCode = subprocessWithImprovedErrors(["cmake", "-DCMAKE_BUILD_TYPE=" + BUILD_TYPE, "-DCMAKE_TOOLCHAIN_FILE=" + CMAKE_TOOLCHAIN_FILE,"."], "cmake")
 	if returnCode != 0:
 		print("There was a problem calling cmake; Return code = " + str(returnCode))
 		return returnCode

--- a/FrameworkInternals/install_framework.py
+++ b/FrameworkInternals/install_framework.py
@@ -20,7 +20,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 '''
 
 import os
-import subprocess
 import platform
 from manage_files import mfInstall
 import __main__

--- a/FrameworkInternals/original_files.txt
+++ b/FrameworkInternals/original_files.txt
@@ -134,6 +134,7 @@ File generateHonkyTonk.py					must_exist,must_be_versioned,md5=check,install=ove
 File install_framework.py					must_exist,must_be_versioned,md5=check,install=overwrite
 File transformDesign.py						must_exist,must_be_versioned,md5=check,install=overwrite
 File runDoxygen.py							must_exist,must_be_versioned,md5=check,install=overwrite
+File externalTooolCheck.py					must_exist,must_be_versioned,md5=check,install=overwrite
 
 Directory RPM install=create
 

--- a/FrameworkInternals/original_files.txt
+++ b/FrameworkInternals/original_files.txt
@@ -135,6 +135,7 @@ File install_framework.py					must_exist,must_be_versioned,md5=check,install=ove
 File transformDesign.py						must_exist,must_be_versioned,md5=check,install=overwrite
 File runDoxygen.py							must_exist,must_be_versioned,md5=check,install=overwrite
 File externalTooolCheck.py					must_exist,must_be_versioned,md5=check,install=overwrite
+File commandMap.py							must_exist,must_be_versioned,md5=check,install=overwrite
 
 Directory RPM install=create
 

--- a/FrameworkInternals/runDoxygen.py
+++ b/FrameworkInternals/runDoxygen.py
@@ -31,6 +31,6 @@ def runDoxygen():
 	os.chdir(baseDirectory + os.path.sep + "Documentation")
 	print("Changing directory to: " + baseDirectory + os.path.sep + "Documentation")
 	print("Calling Doxygen")
-	subprocessWithImprovedErrors("doxygen" , "doxygen")
+	subprocessWithImprovedErrors(getCommand("doxygen") , getCommand("doxygen"))
 	os.chdir(baseDirectory)
 	print("Changing directory to: " + baseDirectory)

--- a/FrameworkInternals/runDoxygen.py
+++ b/FrameworkInternals/runDoxygen.py
@@ -20,8 +20,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 '''
 
 import os
-import subprocess
 import __main__
+from externalToolCheck import subprocessWithImprovedErrors
 
 def runDoxygen():
 	"""Runs doxygen in the documentation folder, making the tool generate documentation for the server automatically."""
@@ -31,6 +31,6 @@ def runDoxygen():
 	os.chdir(baseDirectory + os.path.sep + "Documentation")
 	print("Changing directory to: " + baseDirectory + os.path.sep + "Documentation")
 	print("Calling Doxygen")
-	subprocess.call("doxygen" , shell=True)
+	subprocessWithImprovedErrors("doxygen" , "doxygen")
 	os.chdir(baseDirectory)
 	print("Changing directory to: " + baseDirectory)

--- a/FrameworkInternals/transformDesign.py
+++ b/FrameworkInternals/transformDesign.py
@@ -61,7 +61,6 @@ def transformDesign(xsltTransformation, outputFile, overwriteProtection, astyleR
 	#files
 	XSLT_JAR = '.' + os.path.sep + 'Design' + os.path.sep + 'saxon9he.jar'
 	DESIGN_XML = '.' + os.path.sep + 'Design' + os.path.sep + 'Design.xml'
-
 	if overwriteProtection == 1:
 		originalOutputFile = outputFile
 		outputFile = outputFile + '.generated'
@@ -76,10 +75,14 @@ def transformDesign(xsltTransformation, outputFile, overwriteProtection, astyleR
 		if returnCode != 0:
 			raise Exception("There was a problem generating " + outputFile + "; Return code = " + str(returnCode))
 
-	if astyleRun == 1:
-		returnCode = subprocessWithImprovedErrors(['astyle', outputFile], "astyle")
-		if returnCode != 0:
-			raise Exception("There was a formatting the file " + outputFile + " with astyle; Return code = " + str(returnCode))
+	if astyleRun == 1:		
+		try:
+			returnCode = subprocessWithImprovedErrors(['astyle', outputFile], "astyle")
+			if returnCode != 0:
+				raise Exception("There was a formatting the file " + outputFile + " with astyle; Return code = " + str(returnCode))
+		except Exception, e:			
+			print("Warning: Error when calling astyle: [" + str(e) + "]")
+			print("Execution will continue normally, but astyle wasn't executed.")
 	if overwriteProtection == 1:
 		#If the file existed previously and it is different from the old one we run kdiff3
 		if (os.path.isfile(originalOutputFile)) and (filecmp.cmp(originalOutputFile, outputFile) == False):

--- a/FrameworkInternals/transformDesign.py
+++ b/FrameworkInternals/transformDesign.py
@@ -22,8 +22,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 import os
 import os.path
 import sys
-import subprocess
 import filecmp
+from externalToolCheck import subprocessWithImprovedErrors
 
 # args:
 # $1    xslt transform filename
@@ -68,22 +68,22 @@ def transformDesign(xsltTransformation, outputFile, overwriteProtection, astyleR
 
 	#Do transformation
 	if additionalParam == None:
-		returnCode = subprocess.call(['java', '-jar', XSLT_JAR, DESIGN_XML, xsltTransformation, '-o:' + outputFile])
+		returnCode = subprocessWithImprovedErrors(['java', '-jar', XSLT_JAR, DESIGN_XML, xsltTransformation, '-o:' + outputFile], "java")
 		if returnCode != 0:
 			raise Exception("There was a problem generating " + outputFile + "; Return code = " + str(returnCode))
 	else:
-		returnCode = subprocess.call(['java', '-jar', XSLT_JAR, DESIGN_XML, xsltTransformation, '-o:' + outputFile, additionalParam])
+		returnCode = subprocessWithImprovedErrors(['java', '-jar', XSLT_JAR, DESIGN_XML, xsltTransformation, '-o:' + outputFile, additionalParam], "java")
 		if returnCode != 0:
 			raise Exception("There was a problem generating " + outputFile + "; Return code = " + str(returnCode))
 
 	if astyleRun == 1:
-		returnCode = subprocess.call(['astyle', outputFile])
+		returnCode = subprocessWithImprovedErrors(['astyle', outputFile], "astyle")
 		if returnCode != 0:
 			raise Exception("There was a formatting the file " + outputFile + " with astyle; Return code = " + str(returnCode))
 	if overwriteProtection == 1:
 		#If the file existed previously and it is different from the old one we run kdiff3
 		if (os.path.isfile(originalOutputFile)) and (filecmp.cmp(originalOutputFile, outputFile) == False):
-			returnCode = subprocess.call(['kdiff3', "-o", originalOutputFile, originalOutputFile, outputFile])
+			returnCode = subprocessWithImprovedErrors(['kdiff3', "-o", originalOutputFile, originalOutputFile, outputFile], "kdiff3")
 			if returnCode != 0 and returnCode != 1:#1 is a valid return, since it means that the user quitted without saving the merge, and this is still ok.
 				raise Exception("There was a problem with kdiff3; Return code = " + str(returnCode))
 		else:#If the file didn't exist before, or it is equal to the old one, we rename the generated file to have the proper name

--- a/FrameworkInternals/transformDesign.py
+++ b/FrameworkInternals/transformDesign.py
@@ -24,6 +24,7 @@ import os.path
 import sys
 import filecmp
 from externalToolCheck import subprocessWithImprovedErrors
+from commandMap import getCommand
 
 # args:
 # $1    xslt transform filename
@@ -59,7 +60,7 @@ def transformDesign(xsltTransformation, outputFile, overwriteProtection, astyleR
 	additionalParam -- Optional extra param. If specified, it will be given directly to saxon9he.jar
 	"""
 	#files
-	XSLT_JAR = '.' + os.path.sep + 'Design' + os.path.sep + 'saxon9he.jar'
+	XSLT_JAR = '.' + os.path.sep + 'Design' + os.path.sep + getCommand('saxon')
 	DESIGN_XML = '.' + os.path.sep + 'Design' + os.path.sep + 'Design.xml'
 	if overwriteProtection == 1:
 		originalOutputFile = outputFile
@@ -67,17 +68,17 @@ def transformDesign(xsltTransformation, outputFile, overwriteProtection, astyleR
 
 	#Do transformation
 	if additionalParam == None:
-		returnCode = subprocessWithImprovedErrors(['java', '-jar', XSLT_JAR, DESIGN_XML, xsltTransformation, '-o:' + outputFile], "java")
+		returnCode = subprocessWithImprovedErrors([getCommand('java'), '-jar', XSLT_JAR, DESIGN_XML, xsltTransformation, '-o:' + outputFile], getCommand("java"))
 		if returnCode != 0:
 			raise Exception("There was a problem generating " + outputFile + "; Return code = " + str(returnCode))
 	else:
-		returnCode = subprocessWithImprovedErrors(['java', '-jar', XSLT_JAR, DESIGN_XML, xsltTransformation, '-o:' + outputFile, additionalParam], "java")
+		returnCode = subprocessWithImprovedErrors([getCommand('java'), '-jar', XSLT_JAR, DESIGN_XML, xsltTransformation, '-o:' + outputFile, additionalParam], getCommand("java"))
 		if returnCode != 0:
 			raise Exception("There was a problem generating " + outputFile + "; Return code = " + str(returnCode))
 
 	if astyleRun == 1:		
 		try:
-			returnCode = subprocessWithImprovedErrors(['astyle', outputFile], "astyle")
+			returnCode = subprocessWithImprovedErrors([getCommand('astyle'), outputFile], getCommand("astyle"))
 			if returnCode != 0:
 				raise Exception("There was a formatting the file " + outputFile + " with astyle; Return code = " + str(returnCode))
 		except Exception, e:			
@@ -86,7 +87,7 @@ def transformDesign(xsltTransformation, outputFile, overwriteProtection, astyleR
 	if overwriteProtection == 1:
 		#If the file existed previously and it is different from the old one we run kdiff3
 		if (os.path.isfile(originalOutputFile)) and (filecmp.cmp(originalOutputFile, outputFile) == False):
-			returnCode = subprocessWithImprovedErrors(['kdiff3', "-o", originalOutputFile, originalOutputFile, outputFile], "kdiff3")
+			returnCode = subprocessWithImprovedErrors([getCommand('kdiff3'), "-o", originalOutputFile, originalOutputFile, outputFile], getCommand("kdiff3"))
 			if returnCode != 0 and returnCode != 1:#1 is a valid return, since it means that the user quitted without saving the merge, and this is still ok.
 				raise Exception("There was a problem with kdiff3; Return code = " + str(returnCode))
 		else:#If the file didn't exist before, or it is equal to the old one, we rename the generated file to have the proper name

--- a/quasar.py
+++ b/quasar.py
@@ -56,6 +56,7 @@ from designTools import upgradeDesign
 from designTools import createDiagram
 from generateHonkyTonk import generateHonkyTonk
 from runDoxygen import runDoxygen
+from externalToolCheck import checkExternalDependancies
 
 # format is: [command name], callable
 commands = [
@@ -99,5 +100,12 @@ if '-h' in sys.argv or '--help' in sys.argv:
 	help(matched_command[1])
 	sys.exit(0)
 else:
+	#check that all the external dependancies are working before starting the execution
+	if matched_command[0] == ['generate','diagram']:
+		checkExternalDependancies(True, False)
+	elif matched_command[0] == ['doxygen']:
+		checkExternalDependancies(False, True)
+	else:
+		checkExternalDependancies(False, False)
 	exit_code = matched_command[1]( * sys.argv[1+len(matched_command[0]):])  # pack arguments after the last chunk of the command
 	sys.exit(exit_code)

--- a/quasar.py
+++ b/quasar.py
@@ -56,7 +56,7 @@ from designTools import upgradeDesign
 from designTools import createDiagram
 from generateHonkyTonk import generateHonkyTonk
 from runDoxygen import runDoxygen
-from externalToolCheck import checkExternalDependancies
+from externalToolCheck import checkExternalDependencies
 
 # format is: [command name], callable
 commands = [
@@ -84,6 +84,7 @@ commands = [
 	[['format_design'], formatDesign, True],
 	[['validate_design'], validateDesign, True],	
 	[['doxygen'], runDoxygen, True],	
+	[['dependency_check'], checkExternalDependencies, True],	
 	]
 
 
@@ -100,12 +101,5 @@ if '-h' in sys.argv or '--help' in sys.argv:
 	help(matched_command[1])
 	sys.exit(0)
 else:
-	#check that all the external dependancies are working before starting the execution
-	if matched_command[0] == ['generate','diagram']:
-		checkExternalDependancies(True, False)
-	elif matched_command[0] == ['doxygen']:
-		checkExternalDependancies(False, True)
-	else:
-		checkExternalDependancies(False, False)
 	exit_code = matched_command[1]( * sys.argv[1+len(matched_command[0]):])  # pack arguments after the last chunk of the command
 	sys.exit(exit_code)

--- a/quasarGUI.py
+++ b/quasarGUI.py
@@ -52,6 +52,7 @@ from designTools import upgradeDesign
 from designTools import createDiagram
 from generateHonkyTonk import generateHonkyTonk
 from runDoxygen import runDoxygen
+from externalToolCheck import checkExternalDependencies
 
 exitLoop = False
 myScreen = None
@@ -191,6 +192,7 @@ def createMenus():
 	additionalMenu = SubMenu("     Additional operations     ")
 	additionalMenu.addOption(Option("       Generate Diagram        ", inspect.getdoc(createDiagram), createDiagram, True, "                  Please specify detail level (0 by detault)                    "))
 	additionalMenu.addOption(Option("          Run Doxygen          ", "Runs doxygen in the documentation folder, making the tool generate documentation for the server automatically", runDoxygen, True))
+	additionalMenu.addOption(Option("       Dependency Check        ", inspect.getdoc(checkExternalDependencies), checkExternalDependencies, True))
 	additionalMenu.addOption(Option("            Return             ", "                             Return to the main menu                            ", backToMainMenu, False))
 	exitMenu = SubMenu("             Exit              ")
 	mainMenu.addSubmenu(buildMenu)


### PR DESCRIPTION
Set of python improvements, mainly (but not only) oriented at having better error handling, and dependency checks. Changes include:

- Command dependency_check added to quasar.py and to quasarGUI.py. This command will call the function checkExternalDependencies inside the (newly created) file externalToolCheck.py. This will go trough all the dependencies checking if they are available, and printing messages accordingly. The programs that are checked are the following: Saxon, Java, Kdiff, CMake, Compiler (either make or msbuild), xmllint, astyle (optional dependency), GraphViz (optional dependency), DoxyGen (optional dependency).

- Improved error control when using the subprocess python module. Now instead of calling subprocess directly, the functions subprocessWithImprovedError or subprocessWithImprovedErrorsPipeOutputToFile are called. This functions are defined in the file externalToolCheck, and call subprocess as expected, but managing the exceptions to detect when the command that you are trying to run is non existent or non accessible. In case that you need to pipe the output of a command to a file, subprocessWithImprovedErrorsPipeOutputToFile should be used instead, as the way this was implemented in the past (using the switch shell=True) is unsafe and does not control exceptions. The effect of using this trought all the python scripts is that when a external dependency is used, while it is not available, a proper error message is shown now to the user.

- Astyle changed from compulsory dependency to an optional one. In the past, if astyle failed to execute (because of an error on astyle itself, or because it was not present) the execution of quasar.py just stopped at that point. Now this is not the case anymore, and if there is a problem executing astyle for whatever reason, a warning is printed, and execution of quasar.py goes on. This should have been like this from the beggining, as Astyle only provides asthetical changes into the autogenerated code.

- Introduction of the file commandMap.py, where a map of all the different commands used for calling the external dependencies is stores. So if for example java is called trough the command java9 in the next version, you only have to update this information in commandMap.py, as all the other files will access this information trough the map.