### PR TITLE
Fix for UA API 1.5.x

### DIFF
--- a/Documentation/quasar.html
+++ b/Documentation/quasar.html
@@ -145,6 +145,13 @@ sudo yum install OpcUaToolkit-1.3.3-0.x86_64.rpm astyle-2.0.4-0.rpm</li>
     </ul>
   </li>
 </ol>
+
+<h3>Quick setup hints for Ubuntu (here: 14.04)</h3>
+Execute:<br>
+sudo apt-get install cmake g++ libboost-all-dev libxml2-utils astyle xsdcxx libxerces-c-dev libssl-dev kdiff3 
+
+Note you will need UA SDK (i.e. evaluation version) or alternative backend (consider open62541 with quasar integration).
+
 <h3>Setup for Windows users <br>
 </h3>
 <ol>   

--- a/Server/src/opcserver.cpp
+++ b/Server/src/opcserver.cpp
@@ -20,6 +20,12 @@
 
 #include <version_coremodule.h>
 
+#ifndef CPP_SDK_MAJOR
+#define CPP_SDK_MAJOR PROD_MAJOR
+#define CPP_SDK_MINOR PROD_MINOR
+#define CPP_SDK_MINOR2 PROD_PATCH
+#endif
+
 #define UA_API_VERSION (CPP_SDK_MAJOR * 100 \
                                + CPP_SDK_MINOR * 10 \
                                + CPP_SDK_MINOR2 )
@@ -308,10 +314,6 @@ int OpcServer::start()
     // Check trace settings
     if ( d->m_pServerConfig->loadConfiguration().isGood() )
     {
-		if(VersionInfoCoreModule::getCoreModuleVersion() == UaString("1.5.1.326 / b2dd5e7d778ea11e091aeac8c1c839f5e6b3920d"))
-        {//If the version is 1.5.1.326 we define the macro UATOOLKIT_1_5_1_326, to do a ifdef switch later, because of a small change in the API
-			#define UATOOLKIT_1_5_1_326 1			
-        }
 
         OpcUa_Boolean bTraceEnabled    = OpcUa_False;
         OpcUa_UInt32  uTraceLevel      = 0;

--- a/Server/src/serverconfigxml.cpp
+++ b/Server/src/serverconfigxml.cpp
@@ -16,6 +16,14 @@
 
 /* Support for UA Toolkit API 1.3, 1.4 and 1.5 by pnikiel and damiron */
 /* Note the API is different in these versions wrt to server configuration*/
+
+// Defines storing UA SDK version are unfortunately called differently in 1.5.x compared to previous versions ...
+#ifndef CPP_SDK_MAJOR
+#define CPP_SDK_MAJOR PROD_MAJOR
+#define CPP_SDK_MINOR PROD_MINOR
+#define CPP_SDK_MINOR2 PROD_PATCH
+#endif
+
 #define UA_API_VERSION (CPP_SDK_MAJOR * 100 \
                                + CPP_SDK_MINOR * 10 \
                                + CPP_SDK_MINOR2 )


### PR DESCRIPTION
The previous fix (uatoolkit_14x branch) was supposed to work with 1.3.x, 1.4.x and 1.5.x API, however it turned out that preprocessor defines carrying version information have been renamed in 1.5.x API.

Therefore now, in case "old" defines are not found, "new" ones are used to evaluate SDK version.

I tested this personally with 1.5.1 evaluation version and *don't expect* backward issues with former versions.