### PR TITLE
OPCUA-653 reduce ifdefs

### DIFF
--- a/FrameworkInternals/original_files.txt
+++ b/FrameworkInternals/original_files.txt
@@ -175,6 +175,7 @@ File shutdown.h                             must_exist,must_be_versioned,md5=che
 File serverconfigxml.h                      deprecated
 File serverconfigxml_quasar.h               must_exist,must_be_versioned,md5=check,install=overwrite
 File opcserver.h                            must_exist,must_be_versioned,md5=check,install=overwrite
+File opcserver_open62541.h		    must_exist,must_be_versioned,md5=check,install=overwrite
 File version.h                              must_exist,must_be_versioned,md5=check,install=overwrite
 File QuasarServerCallback.h                 must_exist,must_be_versioned,md5=check,install=overwrite
 File QuasarVersion.h                        must_exist,must_be_versioned,md5=check,install=overwrite
@@ -187,6 +188,7 @@ File QuasarServer.cpp                       must_exist,must_be_versioned,install
 File serverconfigxml.cpp                    must_exist,must_be_versioned,md5=check,install=overwrite
 File shutdown.cpp                           must_exist,must_be_versioned,md5=check,install=overwrite
 File opcserver.cpp                          must_exist,must_be_versioned,md5=check,install=overwrite
+File opcserver_open62541.cpp		    must_exist,must_be_versioned,md5=check,install=overwrite
 File QuasarServerCallback.cpp               must_exist,must_be_versioned,md5=check,install=overwrite
 
 Directory .

--- a/Server/CMakeLists.txt
+++ b/Server/CMakeLists.txt
@@ -18,7 +18,8 @@
 
 add_library (Server OBJECT
 	src/main.cpp 
-	src/opcserver.cpp 
+	src/opcserver.cpp
+	src/opcserver_open62541.cpp
 	src/shutdown.cpp 
 	src/serverconfigxml.cpp 
 	src/QuasarServerCallback.cpp

--- a/Server/include/BaseQuasarServer.h
+++ b/Server/include/BaseQuasarServer.h
@@ -28,6 +28,7 @@
 	#include <uabase.h>
 	#include <opcserver.h>
 #elif BACKEND_OPEN62541
+        #include <opcserver_open62541.h>
 	#include <open62541.h>
 #endif
 
@@ -50,17 +51,9 @@ public:
     //Starts application. Parses command line arguments and then calls serverRun
     int startApplication(int argc, char *argv[]);
 
-#ifdef BACKEND_OPEN62541
-    void runThread();
-#endif
-
 protected:
     //Reference to the OPC UA Server internal implementation    
-#ifdef BACKEND_UATOOLKIT
     OpcServer* m_pServer;
-#elif BACKEND_OPEN62541
-    UA_Server *m_pServer;
-#endif
 
     //Reference to the Node manager
     AddressSpace::ASNodeManager* m_nodeManager;

--- a/Server/include/opcserver.h
+++ b/Server/include/opcserver.h
@@ -1,3 +1,5 @@
+#ifdef BACKEND_UATOOLKIT
+
 /******************************************************************************
 ** opcserver.h
 **
@@ -61,3 +63,5 @@ private:
 
 
 #endif // MAIN_OPCSERVER_H
+
+#endif //  BACKEND_UATOOLKIT

--- a/Server/include/opcserver_open62541.h
+++ b/Server/include/opcserver_open62541.h
@@ -1,0 +1,55 @@
+#ifdef BACKEND_OPEN62541
+
+#ifndef MAIN_OPCSERVER_H
+#define MAIN_OPCSERVER_H
+
+#include <open62541_compat.h>
+#include <ASNodeManager.h>
+#include <boost/thread.hpp>
+
+using AddressSpace::ASNodeManager;
+
+class OpcServer
+{
+    OpcServer(const OpcServer& other) = delete;
+    OpcServer& operator= (const OpcServer& other) = delete;
+
+public:
+    // construction / destruction
+    OpcServer();
+    ~OpcServer();
+
+    // Methods used to initialize the server
+    int setServerConfig(const UaString& configurationFile, const UaString& applicationPath);
+//    int setServerConfig(ServerConfig* pServerConfig);
+    int addNodeManager(ASNodeManager* pNodeManager);
+//    int setCallback(OpcServerCallback* pOpcServerCallback);
+    /* This is just to create a certificate and quit right away */
+    int createCertificate ();
+
+    // Methods used to start and stop the server
+    int start();
+    int stop(OpcUa_Int32 secondsTillShutdown, const UaLocalizedText& shutdownReason);
+
+    // Access to default node manager
+    NodeManagerConfig* getDefaultNodeManager();
+
+    std::string getLogFilePath() { return m_logFilePath; }
+
+private:
+    ASNodeManager *m_nodemanager;
+    std::string m_logFilePath;
+
+    UA_ServerConfig m_server_config;
+    UA_ServerNetworkLayer m_server_network_layer;
+    UA_Server *m_server;
+    boost::thread m_open62541_server_thread;
+
+    void runThread();
+};
+
+
+
+#endif // MAIN_OPCSERVER_H
+
+#endif // BACKEND_OPEN62541

--- a/Server/src/opcserver.cpp
+++ b/Server/src/opcserver.cpp
@@ -1,4 +1,4 @@
-#ifndef BACKEND_OPEN62541
+#ifdef BACKEND_UATOOLKIT
 
 /******************************************************************************
 ** opcserver.cpp
@@ -643,4 +643,4 @@ UaStatus ServerConfigBasicXml::logonSessionUser(
 }
 
 
-#endif // BACKEND_OPEN62541
+#endif // BACKEND_UATOOLKIT

--- a/Server/src/opcserver_open62541.cpp
+++ b/Server/src/opcserver_open62541.cpp
@@ -1,3 +1,5 @@
+#ifdef BACKEND_OPEN62541
+
 #include <opcserver_open62541.h>
 
 #include <LogIt.h>
@@ -78,3 +80,5 @@ void OpcServer::runThread()
 {
     UA_StatusCode retval = UA_Server_run(m_server, &g_RunningFlag);
 }
+
+#endif //  BACKEND_OPEN62541

--- a/Server/src/opcserver_open62541.cpp
+++ b/Server/src/opcserver_open62541.cpp
@@ -1,0 +1,80 @@
+#include <opcserver_open62541.h>
+
+#include <LogIt.h>
+#include <stdexcept>
+#include <Utils.h>
+#include <shutdown.h>
+
+using namespace std;
+
+
+#define throw_runtime_error_with_origin(MSG) throw std::runtime_error(std::string("At ")+__FILE__+":"+Utils::toString(__LINE__)+" "+MSG)
+
+OpcServer::OpcServer():
+    m_nodemanager(0),
+    m_server_config(UA_ServerConfig_standard),
+    m_server_network_layer(UA_ServerNetworkLayerTCP(UA_ConnectionConfig_standard, 4841)),
+    m_server(0)
+{
+    //NOTE: UA_Server created later because it needs configuration (which is supplied later)
+}
+
+/** Destruction. */
+OpcServer::~OpcServer()
+{
+    // UA_Server instance got deleted in stop()
+}
+
+int OpcServer::setServerConfig(const UaString& configurationFile, const UaString& applicationPath)
+{
+    LOG(Log::INF) << "Note: with open62541 backend, there isn't (yet) XML configuration loading. Assuming hardcoded server settings (endpoint's port, etc.)";
+    // NOTE: some basid settings are configured in ctr init list
+    // TODO: XML config reading
+    m_server_config = UA_ServerConfig_standard;
+    m_server_network_layer = UA_ServerNetworkLayerTCP(UA_ConnectionConfig_standard, 4841);
+    m_server_config.networkLayers = &m_server_network_layer;
+    m_server_config.networkLayersSize = 1;
+    return 0;
+}
+
+int OpcServer::addNodeManager(ASNodeManager* pNodeManager)
+{
+    if (!m_nodemanager)
+	m_nodemanager = pNodeManager;
+    else
+	throw_runtime_error_with_origin("Sorry, only 1 NodeManager is supported.");
+    return 0;
+}
+
+int OpcServer::createCertificate ()
+{
+    LOG(Log::ERR) << "Sorry, certificate creation is not supported(yet) with open62541 backend.";
+    return -1;
+}
+
+int OpcServer::start()
+{
+    m_server = UA_Server_new(m_server_config);
+    if (!m_server)
+	throw_runtime_error_with_origin("UA_Server_new failed");
+    m_nodemanager->linkServer(m_server);
+    m_nodemanager->afterStartUp();
+    m_open62541_server_thread = boost::thread ( &OpcServer::runThread, this );
+    return 0;
+
+}
+
+int OpcServer::stop(OpcUa_Int32 secondsTillShutdown, const UaLocalizedText& shutdownReason)
+{
+    delete m_nodemanager;
+    m_nodemanager = 0;
+    UA_Server_delete(m_server);
+    m_server = 0;
+    return 0;
+}
+
+
+void OpcServer::runThread()
+{
+    UA_StatusCode retval = UA_Server_run(m_server, &g_RunningFlag);
+}


### PR DESCRIPTION
The purpose is simplification and removal of backend-specific things in BaseQuasarServer class. Almost all backend-specific things were moved to OpcServer (existing previously) but now 2 implementations exist (one per each  backend).

This cleanup reduced number of ifdefs from 19 to 5 in cpp file, and also few in the header file.

The philosophy is similar to open62541-compat module: open62541-compatible implementation was provided for UA API OpcServer interface.
