### PR TITLE
Add ci build tags to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Quick opcUA Server generAtion fRamework
 ## Out-of-the-box dependencies.
 Once you've cloned the quasar framework git repository to your development machine you'll need to obtain some dependencies before you can start developing. Due to licensing, these dependencies can't be distributed with the quasar code, but please read _quasar-checkout-dir_/Documentation/GenericServer.html for detail.
 
-## Build statuses (master branch)
+## Builds status (master branch)
 Linux
-[![travis-ci](https://travis-ci.org/quasar-team/quasar.svg?branch=master)]
+![travis-ci](https://travis-ci.org/quasar-team/quasar.svg?branch=master)
 
 Windows
-[![Appveyor](https://ci.appveyor.com/api/projects/status/q8ruqgd2nj54b76p/branch/master?svg=true)]
+![Appveyor](https://ci.appveyor.com/api/projects/status/q8ruqgd2nj54b76p/branch/master?svg=true)
 
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Once you've cloned the quasar framework git repository to your development machi
 
 ## Continuous Integration builds status (master branch)
 
-CI build info | CI build status
------------- | -------------
-linux (travis-ci) | ![travis-ci](https://travis-ci.org/quasar-team/quasar.svg?branch=master)
-windows (appveyor) | ![Appveyor](https://ci.appveyor.com/api/projects/status/q8ruqgd2nj54b76p/branch/master?svg=true)
+CI build info | UA backend | CI build status
+------------ | ------------- | -------------
+linux (travis-ci) | open62541 | ![travis-ci](https://travis-ci.org/quasar-team/quasar.svg?branch=master)
+windows (appveyor) | open62541 | ![Appveyor](https://ci.appveyor.com/api/projects/status/q8ruqgd2nj54b76p/branch/master?svg=true)

--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ Once you've cloned the quasar framework git repository to your development machi
 CI build info | CI build status
 ------------ | -------------
 linux (travis-ci) | ![travis-ci](https://travis-ci.org/quasar-team/quasar.svg?branch=master)
-windows (appveyor) CI build | ![Appveyor](https://ci.appveyor.com/api/projects/status/q8ruqgd2nj54b76p/branch/master?svg=true)
+windows (appveyor) | ![Appveyor](https://ci.appveyor.com/api/projects/status/q8ruqgd2nj54b76p/branch/master?svg=true)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ Linux
 coming soon...
 
 Windows
-https://ci.appveyor.com/api/projects/status/q8ruqgd2nj54b76p/branch/master?svg=true
+[![Appveyor](https://ci.appveyor.com/api/projects/status/q8ruqgd2nj54b76p/branch/master?svg=true)]
 
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,9 @@ Quick opcUA Server generAtion fRamework
 ## Out-of-the-box dependencies.
 Once you've cloned the quasar framework git repository to your development machine you'll need to obtain some dependencies before you can start developing. Due to licensing, these dependencies can't be distributed with the quasar code, but please read _quasar-checkout-dir_/Documentation/GenericServer.html for detail.
 
-## Builds status (master branch)
-Linux
-![travis-ci](https://travis-ci.org/quasar-team/quasar.svg?branch=master)
+## Continuous Integration builds status (master branch)
 
-Windows
-![Appveyor](https://ci.appveyor.com/api/projects/status/q8ruqgd2nj54b76p/branch/master?svg=true)
-
-
+CI build info | CI build status
+------------ | -------------
+linux (travis-ci) | ![travis-ci](https://travis-ci.org/quasar-team/quasar.svg?branch=master)
+windows (appveyor) CI build | ![Appveyor](https://ci.appveyor.com/api/projects/status/q8ruqgd2nj54b76p/branch/master?svg=true)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Once you've cloned the quasar framework git repository to your development machi
 
 ## Build statuses (master branch)
 Linux
-coming soon...
+[![travis-ci](https://travis-ci.org/quasar-team/quasar.svg?branch=master)]
 
 Windows
 [![Appveyor](https://ci.appveyor.com/api/projects/status/q8ruqgd2nj54b76p/branch/master?svg=true)]

--- a/README.md
+++ b/README.md
@@ -3,3 +3,12 @@ Quick opcUA Server generAtion fRamework
 
 ## Out-of-the-box dependencies.
 Once you've cloned the quasar framework git repository to your development machine you'll need to obtain some dependencies before you can start developing. Due to licensing, these dependencies can't be distributed with the quasar code, but please read _quasar-checkout-dir_/Documentation/GenericServer.html for detail.
+
+## Build statuses (master branch)
+Linux
+coming soon...
+
+Windows
+https://ci.appveyor.com/api/projects/status/q8ruqgd2nj54b76p/branch/master?svg=true
+
+


### PR DESCRIPTION
Hi All,

Now that the linux and windows CI builds have been restored (and passing!) we should add the build status flags to our readme. Looks like this

<img width="995" alt="screen shot 2016-09-01 at 21 10 09" src="https://cloud.githubusercontent.com/assets/319874/18180769/9574777a-7088-11e6-9888-aa73d3a0f35c.png">

Change only affects the readme.md - Piotr, if you like the look of this then please just merge this in.

Cheers,
Ben