### PR TITLE
Travis with docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,22 @@
+sudo: required
+
 language: cpp
-compiler: gcc
+
+services:
+ - docker
+
 before_install:
- - sudo apt-get install -y libxml2-dev libxerces-c-dev python-svn python-lxml astyle libboost-all-dev xsdcxx default-jre libssl-dev gcc-multilib g++-multilib
- - wget --no-check-certificate https://cmake.org/files/v2.8/cmake-2.8.12.2.tar.gz
- - tar -xzvf cmake-2.8.12.2.tar.gz 
- - cd cmake-2.8.12.2
- - ./bootstrap
- - make      
- - sudo make install
- - cd ..
+ - docker pull bfarnham/quasar:quasar-open62541
  
 script:
- - cmake -version
-
-# obtain CI helper content, insert specific Design.xml into project.
- - git clone https://github.com/quasar-team/quasar-validation-ci.git
- - mv quasar-validation-ci/CI/Design.xml Design/
-
-# run code generation from Design.xml
- - python quasar.py generate device GreenLED
- - python quasar.py generate device YellowLED
- - python quasar.py generate device RedLED
-
-# start: below should be replaceable by 'enable module' for open62541-compat, doesn't 
-# appear to work for (non master) branches currently.
- - git clone https://ben-farnham@github.com/quasar-team/open62541-compat.git
- - cd open62541-compat/
- - git checkout open62541_v0.2
- - python prepare.py
- - cd ..
-# end: (replaceable by 'enable module')
-
-# select boost libraries to link against and invoke build
- - export BOOST_LIBS="-lboost_thread -lboost_system -lboost_program_options -lboost_system"
- - python quasar.py build Release open62541_config.cmake
+ - docker run  --interactive --tty bfarnham/quasar:quasar-open62541 /bin/sh -c "\ 
+     git clone https://github.com/quasar-team/quasar.git ;\
+     cd quasar ;\
+     git checkout travis_with_docker ;\ #NB - branch specific, delete line for master
+     git clone https://ben-farnham@github.com/quasar-team/open62541-compat.git ;\
+     cd open62541-compat ;\
+     git checkout open62541_v0.2 ;\
+     python prepare.py ;\
+     cd .. ;\
+     python quasar.py build Release open62541_config.cmake ;\
+     exit"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,14 @@ before_install:
  - docker pull bfarnham/quasar:quasar-open62541
  
 script:
- - docker run  --interactive --tty bfarnham/quasar:quasar-open62541 /bin/sh -c "\ 
-     git clone https://github.com/quasar-team/quasar.git ;\
-     cd quasar ;\
-     git checkout travis_with_docker ;\ #NB - branch specific, delete line for master
-     git clone https://ben-farnham@github.com/quasar-team/open62541-compat.git ;\
-     cd open62541-compat ;\
-     git checkout open62541_v0.2 ;\
-     python prepare.py ;\
-     cd .. ;\
-     python quasar.py build Release open62541_config.cmake ;\
+ - docker run  --interactive --tty bfarnham/quasar:quasar-open62541 /bin/sh -c " 
+     git clone https://github.com/quasar-team/quasar.git ;
+     cd quasar ;
+     git checkout travis_with_docker ;
+     git clone https://ben-farnham@github.com/quasar-team/open62541-compat.git ;
+     cd open62541-compat ;
+     git checkout open62541_v0.2 ;
+     python prepare.py ;
+     cd .. ;
+     python quasar.py build Release open62541_config.cmake ;
      exit"

--- a/open62541_config.cmake
+++ b/open62541_config.cmake
@@ -23,10 +23,14 @@ else(DEFINED ENV{BOOST_PATH_HEADERS})
     message ("Assuming standard Boost installation as no BOOST_PATH_HEADERS is defined in your environment")
     SET( BOOST_PATH_HEADERS "" )
     SET( BOOST_PATH_LIBS "" )
-    SET( BOOST_LIBS "-lboost_program_options -lboost_thread" )
+    if( NOT DEFINED ENV{BOOST_LIBS} )
+      SET( BOOST_LIBS "-lboost_program_options -lboost_thread" )
+    else()
+      SET( BOOST_LIBS $ENV{BOOST_LIBS} )
+    endif()
 endif(DEFINED ENV{BOOST_PATH_HEADERS})
 
-message ("using BOOST_LIBS [$ENV{BOOST_LIBS}]")
+message ("using BOOST_LIBS [${BOOST_LIBS}]")
 
 #------
 #OPCUA


### PR DESCRIPTION
Moved the build from the native travis node (where build problems are almost impossible to debug) to a public docker image which is easy to debug (install docker locally, pull the image and run the same commands as travis runs from the .travis.yml script)

Latest image cached in docker.com
https://hub.docker.com/r/bfarnham/quasar/tags/

Image built from this docker file
https://github.com/quasar-team/docker/blob/master/CC7_Open62541/Dockerfile