### PR TITLE
Travis uses open62541-compat deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ script:
  - docker run  --interactive --tty bfarnham/quasar:quasar-open62541 /bin/sh -c " 
      git clone https://github.com/quasar-team/quasar.git ;
      cd quasar ;
-     git clone https://ben-farnham@github.com/quasar-team/open62541-compat.git ;
+     python quasar.py enable_module open62541-compat ;
+     python quasar.py prepare_build Release open62541_config.cmake ;
      cd open62541-compat ;
-     git checkout open62541_v0.2 ;
      python prepare.py ;
      cd .. ;
      python quasar.py build Release open62541_config.cmake ;


### PR DESCRIPTION
The changes are to follow new convention of "open62541-compat" deployment.
It passed travis build:

https://travis-ci.org/quasar-team/quasar/builds/168867625