### PR TITLE
Adding ByteStream to supported data types

### DIFF
--- a/AddressSpace/designToClassBody.xslt
+++ b/AddressSpace/designToClassBody.xslt
@@ -244,7 +244,10 @@ UaVariant v;
 <xsl:choose>
 <xsl:when test="@dataType='UaVariant'"> 
 v = value;
-
+</xsl:when>
+<xsl:when test="@dataType='UaByteString'">
+//NOTE: const_case below is safe, mutability is required only if value is to be detached (and it isn't in our case)
+v.setByteString( const_cast&lt;UaByteString&amp;&gt;(value), /*detach value?*/ false );
 </xsl:when>
 <xsl:otherwise>
 v.<xsl:value-of select="fnc:dataTypeToVariantSetter(@dataType)"/>( value );

--- a/Configuration/designToConfigurationXSD.xslt
+++ b/Configuration/designToConfigurationXSD.xslt
@@ -42,6 +42,7 @@ xsi:schemaLocation="http://www.w3.org/1999/XSL/Transform schema-for-xslt20.xsd "
 	<xsl:when test="$dataType='OpcUa_Boolean'">xs:boolean</xsl:when>
 	<xsl:when test="$dataType='OpcUa_Double'">xs:double</xsl:when>
 	<xsl:when test="$dataType='OpcUa_Float'">xs:float</xsl:when>
+	<xsl:when test="$dataType='UaByteString'"><xsl:message terminate="yes">ERROR: it is not allowed to initialize a variable of ByteString type from configuration due to ambiguity of input format. If you need this feature, please do ask quasar team for implementation.</xsl:message></xsl:when>
 	<xsl:when test="$dataType='UaVariant'"><xsl:message terminate="yes">ERROR: it is not allowed to initialize a variable of variable type (UaVariant) from configuration.</xsl:message></xsl:when>
 	<xsl:otherwise><xsl:message terminate="yes">ERROR: unknown type <xsl:value-of select="$dataType"/></xsl:message></xsl:otherwise>
 	</xsl:choose>

--- a/Design/CommonFunctions.xslt
+++ b/Design/CommonFunctions.xslt
@@ -197,6 +197,7 @@ ASSOURCEVARIABLE_<xsl:value-of select="$className"/>_WRITE_<xsl:value-of select=
 <xsl:when test="$dataType='OpcUa_Int64'">toInt64</xsl:when>
 <xsl:when test="$dataType='OpcUa_UInt64'">toUInt64</xsl:when>
 <xsl:when test="$dataType='OpcUa_Boolean'">toBool</xsl:when>
+<xsl:when test="$dataType='UaByteString'">toByteString</xsl:when>
 <xsl:when test="$dataType='UaString'"><xsl:message terminate="yes">Internal error - for UaString use toString() conversion</xsl:message></xsl:when>
 <xsl:otherwise><xsl:message terminate="yes">Sorry, this dataType='<xsl:value-of select="$dataType"/>' is unknown.</xsl:message></xsl:otherwise>
 </xsl:choose>
@@ -218,6 +219,7 @@ ASSOURCEVARIABLE_<xsl:value-of select="$className"/>_WRITE_<xsl:value-of select=
 <xsl:when test="$dataType='OpcUa_UInt64'">setUInt64</xsl:when>
 <xsl:when test="$dataType='OpcUa_Boolean'">setBool</xsl:when>
 <xsl:when test="$dataType='UaString'">setString</xsl:when>
+<xsl:when test="$dataType='UaByteString'">setByteString</xsl:when>
 <xsl:otherwise><xsl:message terminate="yes">Sorry, this dataType='<xsl:value-of select="$dataType"/>' is unknown.</xsl:message></xsl:otherwise>
 </xsl:choose>
 </xsl:function>

--- a/Design/CommonFunctions.xslt
+++ b/Design/CommonFunctions.xslt
@@ -178,6 +178,7 @@ ASSOURCEVARIABLE_<xsl:value-of select="$className"/>_WRITE_<xsl:value-of select=
 <xsl:when test="$dataType='OpcUa_UInt64'">OpcUaType_UInt64</xsl:when>
 <xsl:when test="$dataType='OpcUa_Boolean'">OpcUaType_Boolean</xsl:when>
 <xsl:when test="$dataType='UaString'">OpcUaType_String</xsl:when>
+<xsl:when test="$dataType='UaByteString'">OpcUaType_ByteString</xsl:when>
 <xsl:otherwise><xsl:message terminate="yes">Sorry, this dataType='<xsl:value-of select="$dataType"/>' is unknown.</xsl:message></xsl:otherwise>
 </xsl:choose>
 </xsl:function>

--- a/Design/Design.xsd
+++ b/Design/Design.xsd
@@ -211,6 +211,7 @@ elementFormDefault="qualified">
     		<enumeration value="OpcUa_Boolean"></enumeration>
     		<enumeration value="UaString"></enumeration>
     		<enumeration value="UaVariant"></enumeration>
+    		<enumeration value="UaByteString"></enumeration>
     	</restriction>
     </simpleType>
 


### PR DESCRIPTION
The feature was tested with a cache variable in both directions - reading and writing - from OPC-UA client.