### PR TITLE
added a switch to skip tedious merging

### DIFF
--- a/FrameworkInternals/deviceGenerators.py
+++ b/FrameworkInternals/deviceGenerators.py
@@ -24,6 +24,10 @@ from transformDesign import transformDesignVerbose
 from lxml import etree 
 from manage_files import get_list_classes
 
+overwriteProtection=2 #keep original (buffer A)
+# 1=manual merge, as default
+# 0=overwrite with generated
+
 devicePath = "Device" + os.path.sep
 def generateRoot():	
 	"""Generates the files DRoot.h and DRoot.cpp. This method is called automatically by cmake, it does not need to be called by the user."""
@@ -50,6 +54,7 @@ def generateDeviceClass(*classList):
 	Keyword arguments:
 	classname -- the name of the device, which this class will be associated to. You can specify several classes (up to 10), separated by spaces or just --all to regenerate all device classes.
 	"""
+	print("===(FrameworkInternals/deviceGenerators.py:) overwriteProtection= ", overwriteProtection, " is hardcoded (manual merge=1, keepA=2, overwrite=0)===")
 	if(len(classList) == 0):
 		print("Please, provide the name of the class you wish to generate")
 		return
@@ -59,10 +64,10 @@ def generateDeviceClass(*classList):
 	classList = [x for x in classList if x is not None]#Remove nones from the list
 	for c in classList:#generate all the specified device classes
 		output = "include/D" + c + ".h"
-		transformDesignVerbose(devicePath + "designToDeviceHeader.xslt", devicePath + output, 1, 1, "className=" + c)
+		transformDesignVerbose(devicePath + "designToDeviceHeader.xslt", devicePath + output, overwriteProtection, 1, "className=" + c)
 			
 		output = "src/D" + c + ".cpp"
-		transformDesignVerbose(devicePath + "designToDeviceBody.xslt", devicePath + output, 1, 1,"className=" + c)
+		transformDesignVerbose(devicePath + "designToDeviceBody.xslt", devicePath + output, overwriteProtection, 1,"className=" + c)
 	
 def generateAllDevices():
 	"""Generates the files D<classname>.h and D<classname>.cpp for ALL the different devices. This method needs to be called by the user, as this is the class where the device logic is, so a manual merge will be needed.	"""
@@ -71,7 +76,7 @@ def generateAllDevices():
 	for tuple in classes:
 		classname = tuple['name']
 		output = "include/D" + classname + ".h"
-		transformDesignVerbose(devicePath + "designToDeviceHeader.xslt", devicePath + output, 1, 1, "className=" + classname)
+		transformDesignVerbose(devicePath + "designToDeviceHeader.xslt", devicePath + output, overwriteProtection, 1, "className=" + classname)
 			
 		output = "src/D" + classname + ".cpp"
-		transformDesignVerbose(devicePath + "designToDeviceBody.xslt", devicePath + output, 1, 1,"className=" + classname)
+		transformDesignVerbose(devicePath + "designToDeviceBody.xslt", devicePath + output, overwriteProtection, 1,"className=" + classname)

--- a/FrameworkInternals/deviceGenerators.py
+++ b/FrameworkInternals/deviceGenerators.py
@@ -24,9 +24,10 @@ from transformDesign import transformDesignVerbose
 from lxml import etree 
 from manage_files import get_list_classes
 
-overwriteProtection=2 #keep original (buffer A)
+overwriteProtection=1 
+# 2=keep original (buffer A)
 # 1=manual merge, as default
-# 0=overwrite with generated
+# 0=overwrite with generated (buffer B)
 
 devicePath = "Device" + os.path.sep
 def generateRoot():	


### PR DESCRIPTION
Dear All,
I have extended the FrameworkInternals/deviceGenerators.py with a flag which allows to optionally skip the tedious kdiff:

overwriteProtection=1 
# 2=keep original (buffer A)
# 1=manual merge, as default
# 0=overwrite with generated (buffer B)

plus a small if-else py code extension.

We should probably adapt a more global config file to steer the python scripts, using a config file for that [and switching astyle behavior ?] Anyway, this flag can be hardcoded as well. Please take a look and pull it in if you like it. The behaviour stays as it is default==1. Set it to 2 for more fun.

Greetings, Michael