### PR TITLE
Use optional modules in windows ci build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,19 +17,11 @@ install:
 build_script:
   - cmd : SET 
 
-# Get the LED traffic light Design.xml
-#  - cmd : mv --force quasar-validation-ci/CI/Design.xml Design/
-  
 # open6 specific operations
   - cmd : python quasar.py enable_module open62541-compat
   - cmd : python quasar.py prepare_build Release open6_win_configuration.cmake 
   - cmd : cd open62541-compat && python prepare.py && cd ..
 
-# run generator on Design.xml devices
-#  - cmd : python quasar.py generate device GreenLED
-#  - cmd : python quasar.py generate device YellowLED
-#  - cmd : python quasar.py generate device RedLED
-  
 # start build
   - cmd : echo "Calling build...(note always returns 0 to mask any internal msbuild errors - exe is checked below)"
   - cmd : python quasar.py build Release open6_win_configuration.cmake && exit 0
@@ -45,5 +37,5 @@ build_script:
          }
 
 # uncomment to block VM deletion for investigating broken builds.
-on_finish:
-  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+#on_finish:
+#  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,15 +21,8 @@ build_script:
   - cmd : mv --force quasar-validation-ci/CI/Design.xml Design/
   
 # open6 specific operations
-# 2 lines below SHOULD work - optional modules doesn't seem to respect my tag (says it doesn't exist)
-#  - python quasar.py enable_module open62541-compat open62541-compat-0.2-rc2
-#  - python quasar.py prepare_build open62541_config.cmake
-#  - ps : start-process -FilePath git -ArgumentList ("clone", "-b", "open62541_v0.2","--single-branch", "https://github.com/quasar-team/open62541-compat.git") -Wait
-  - cmd : git clone -b open62541_v0.2 --single-branch https://github.com/quasar-team/open62541-compat.git
-  - cmd : cd open62541-compat
-  - cmd : python prepare.py
-  - cmd : dir include
-  - cmd : cd ..
+  - cmd : python quasar.py enable_module open62541-compat
+  - cmd : python quasar.py prepare_build open6_win_configuration.cmake 
 
 # run generator on Design.xml devices
   - cmd : python quasar.py generate device GreenLED

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ build_script:
   - cmd : SET 
 
 # open6 specific operations
-  - cmd : python quasar.py enable_module open62541-compat fix_for_windows_compatibility
+  - cmd : python quasar.py enable_module open62541-compat
   - cmd : python quasar.py prepare_build Release open6_win_configuration.cmake 
   - cmd : cd open62541-compat && python prepare.py && cd ..
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,5 +45,5 @@ build_script:
          }
 
 # uncomment to block VM deletion for investigating broken builds.
-# on_finish:
-#   - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+on_finish:
+  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,7 @@ build_script:
 # open6 specific operations
   - cmd : python quasar.py enable_module open62541-compat
   - cmd : python quasar.py prepare_build open6_win_configuration.cmake 
+  - cmd : cd open62541-compat && python prepare.py && cd ..
 
 # run generator on Design.xml devices
   - cmd : python quasar.py generate device GreenLED

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ build_script:
   - cmd : SET 
 
 # Get the LED traffic light Design.xml
-  - cmd : mv --force quasar-validation-ci/CI/Design.xml Design/
+#  - cmd : mv --force quasar-validation-ci/CI/Design.xml Design/
   
 # open6 specific operations
   - cmd : python quasar.py enable_module open62541-compat
@@ -26,9 +26,9 @@ build_script:
   - cmd : cd open62541-compat && python prepare.py && cd ..
 
 # run generator on Design.xml devices
-  - cmd : python quasar.py generate device GreenLED
-  - cmd : python quasar.py generate device YellowLED
-  - cmd : python quasar.py generate device RedLED
+#  - cmd : python quasar.py generate device GreenLED
+#  - cmd : python quasar.py generate device YellowLED
+#  - cmd : python quasar.py generate device RedLED
   
 # start build
   - cmd : echo "Calling build...(note always returns 0 to mask any internal msbuild errors - exe is checked below)"
@@ -45,5 +45,5 @@ build_script:
          }
 
 # uncomment to block VM deletion for investigating broken builds.
-# on_finish:
-#   - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+on_finish:
+  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ build_script:
   - cmd : SET 
 
 # open6 specific operations
-  - cmd : python quasar.py enable_module open62541-compat
+  - cmd : python quasar.py enable_module open62541-compat fix_for_windows_compatibility
   - cmd : python quasar.py prepare_build Release open6_win_configuration.cmake 
   - cmd : cd open62541-compat && python prepare.py && cd ..
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ build_script:
   
 # open6 specific operations
   - cmd : python quasar.py enable_module open62541-compat
-  - cmd : python quasar.py prepare_build open6_win_configuration.cmake 
+  - cmd : python quasar.py prepare_build Release open6_win_configuration.cmake 
   - cmd : cd open62541-compat && python prepare.py && cd ..
 
 # run generator on Design.xml devices
@@ -45,5 +45,5 @@ build_script:
          }
 
 # uncomment to block VM deletion for investigating broken builds.
-on_finish:
-  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+# on_finish:
+#   - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/open6_win_configuration.cmake
+++ b/open6_win_configuration.cmake
@@ -139,7 +139,7 @@ SET( OPENSSL_LIBS custlibopenssl custlibssl custlibcrypto )
 #-----
 if(NOT TARGET libxercesc) 
 	add_library(libxercesc STATIC IMPORTED)
-	set_property(TARGET libxercesc PROPERTY IMPORTED_LOCATION ${XERCESC_PATH}/VC10/Debug/xerces-c_3D.lib)		
+	set_property(TARGET libxercesc PROPERTY IMPORTED_LOCATION ${XERCESC_PATH}/VC10/Release/xerces-c_3.lib)		
 endif()
 if(NOT TARGET custlibxml) 
 	add_library(custlibxml STATIC IMPORTED)
@@ -162,8 +162,19 @@ include_directories(
 add_definitions( -DBACKEND_OPEN62541 )
 SET( OPCUA_TOOLKIT_PATH "" )
 
-SET( OPCUA_TOOLKIT_LIBS_RELEASE "${PROJECT_SOURCE_DIR}/open62541-compat/open62541/build/Release/open62541.lib" )
-SET( OPCUA_TOOLKIT_LIBS_DEBUG "${PROJECT_SOURCE_DIR}/open62541-compat/open62541/build/Release/open62541.lib" )
+if(NOT TARGET open62541release)
+	add_library(open62541release STATIC IMPORTED)
+	set_property(TARGET open62541release PROPERTY IMPORTED_LOCATION ${PROJECT_SOURCE_DIR}/open62541-compat/open62541/build/Release/open62541.lib)
+endif()
+
+if(NOT TARGET open62541debug)
+	add_library(open62541debug STATIC IMPORTED)
+	set_property(TARGET open62541debug PROPERTY IMPORTED_LOCATION ${PROJECT_SOURCE_DIR}/open62541-compat/open62541/build/Debug/open62541.lib)
+endif()
+
+
+SET( OPCUA_TOOLKIT_LIBS_RELEASE open62541release )
+SET( OPCUA_TOOLKIT_LIBS_DEBUG open62541debug )
 
 #------
 #General

--- a/open6_win_configuration.cmake
+++ b/open6_win_configuration.cmake
@@ -160,7 +160,6 @@ include_directories(
 #OPCUA
 #------
 add_definitions( -DBACKEND_OPEN62541 )
-SET( CUSTOM_SERVER_MODULES open62541-compat)
 SET( OPCUA_TOOLKIT_PATH "" )
 
 SET( OPCUA_TOOLKIT_LIBS_RELEASE "${PROJECT_SOURCE_DIR}/open62541-compat/open62541/build/Release/open62541.lib" )


### PR DESCRIPTION
Sigh, still finding and cleaning up unpleasant findings in the windows CI build. Some my fault, too hasty a job done I think. Still, the situation is the situation and here are 2 options for reaching the light at the end of the windows CI build tunnel (and let's hope the light is not a train coming).

==option 1==
To get a passing windows CI build in the _pnikiel_methods_ quasar branch before it is merged to master the following needs to happen...

1. Merge the **open62541-compat** [pull request #9](https://github.com/quasar-team/open62541-compat/pull/9) to master. This makes an open62541-compat module in the **master** branch that once again builds on windows. It should have always been like that, I failed to notice a static tag in the windows CI build instructions, so the open62541-compat module has slowly been drifting away from MSVC compatibility. Bad, shouldn't not happen any more.

2. Merge this pull request to quasar branch _pnikiel_methods_. As you can see by the modified files, the changes are entirely windows specifc.

==option 2==
Reject this pull request. We can make the windows CI build work just after the pnikiel_methods branch is merged to master.

1. Reject this pull request
2. You merge _pnikiel_methods_ to master
3. Immediately after we merge
a) merge **open62541-compat** [pull request #9](https://github.com/quasar-team/open62541-compat/pull/9) to master (same as option 1 step 1 above).
b)  _use_optional_modules_in_windows_CI_build_ to **quasar** master.
