### PR TITLE
CI builds no longer use python to setup open6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,5 @@ script:
      python quasar.py enable_module open62541-compat ;
      python quasar.py set_build_config open62541_config.cmake ;
      python quasar.py prepare_build Release ;
-     cd open62541-compat ;
-     python prepare.py ;
-     cd .. ;
      python quasar.py build Release ;
      exit"

--- a/open62541_config.cmake
+++ b/open62541_config.cmake
@@ -41,6 +41,7 @@ add_definitions( -DBACKEND_OPEN62541 )
 SET( OPCUA_TOOLKIT_PATH "" )
 SET( OPCUA_TOOLKIT_LIBS_RELEASE "${PROJECT_SOURCE_DIR}/open62541-compat/open62541/build/libopen62541.a" -lrt)
 SET( OPCUA_TOOLKIT_LIBS_DEBUG "${PROJECT_SOURCE_DIR}/open62541-compat/open62541/build/libopen62541.a" -lrt)
+include_directories( open62541-compat/open62541 )
 
 #-----
 #XML Libs

--- a/open62541_config.cmake
+++ b/open62541_config.cmake
@@ -39,8 +39,8 @@ message ("using BOOST_LIBS [${BOOST_LIBS}]")
 # No OPC-UA Toolkit: using Open62541-compat instead. It is referenced in BACKEND_MODULES below
 add_definitions( -DBACKEND_OPEN62541 )
 SET( OPCUA_TOOLKIT_PATH "" )
-SET( OPCUA_TOOLKIT_LIBS_RELEASE "${PROJECT_SOURCE_DIR}/open62541-compat/open62541/build/libopen62541.a" -lrt)
-SET( OPCUA_TOOLKIT_LIBS_DEBUG "${PROJECT_SOURCE_DIR}/open62541-compat/open62541/build/libopen62541.a" -lrt)
+SET( OPCUA_TOOLKIT_LIBS_RELEASE "${PROJECT_SOURCE_DIR}/open62541-compat/open62541/libopen62541.a" -lrt)
+SET( OPCUA_TOOLKIT_LIBS_DEBUG "${PROJECT_SOURCE_DIR}/open62541-compat/open62541/libopen62541.a" -lrt)
 include_directories( open62541-compat/open62541 )
 
 #-----


### PR DESCRIPTION
Required as a consequence (actually a benefit) of the merge just carried out in open62541-compat.