### PR TITLE
Quasar Thread Pool, and its application to source variables

### DIFF
--- a/AddressSpace/designToSourceVariablesBody.xslt
+++ b/AddressSpace/designToSourceVariablesBody.xslt
@@ -287,12 +287,20 @@ xsi:schemaLocation="http://www.w3.org/1999/XSL/Transform schema-for-xslt20.xsd "
 	/* The thread pool should be initialized by Meta while reading the config file, using function: 
 	    SourceVariables_initSourceVariablesThreadPool */
 	static Quasar::ThreadPool *sourceVariableThreads = 0; 
-	void SourceVariables_initSourceVariablesThreadPool (unsigned int minThreads, unsigned int maxThreads)
+	void SourceVariables_initSourceVariablesThreadPool (unsigned int minThreads, unsigned int maxThreads, unsigned int maxJobs)
 	{
-	    LOG(Log::DBG) &lt;&lt; "Initializing source variables thread pool to min=" &lt;&lt; minThreads  &lt;&lt; " max=" &lt;&lt; maxThreads &lt;&lt; " threads";
-		sourceVariableThreads = new Quasar::ThreadPool (maxThreads, /*jobs*/30000);
+	    LOG(Log::DBG) &lt;&lt; "Initializing source variables thread pool to min=" &lt;&lt; minThreads  &lt;&lt; " max=" &lt;&lt; maxThreads &lt;&lt; " threads maxJobs=" &lt;&lt; " jobs";
+		sourceVariableThreads = new Quasar::ThreadPool (maxThreads, maxJobs);
 	}
 
+    void SourceVariables_destroySourceVariablesThreadPool ()
+    {
+        if (sourceVariableThreads)
+        {
+            delete sourceVariableThreads;
+            sourceVariableThreads = nullptr;
+        }
+    }
 
 		<xsl:for-each select="/d:design/d:class">
 		<xsl:variable name="className"><xsl:value-of select="@name"/></xsl:variable>

--- a/AddressSpace/designToSourceVariablesBody.xslt
+++ b/AddressSpace/designToSourceVariablesBody.xslt
@@ -351,7 +351,7 @@ UaStatus SourceVariables_spawnIoJobRead (
 				parentNode
 				); 
 				UaStatus s = sourceVariableThreads-&gt;addJob (job);
-                if (!s.isGood)
+                if (!s.isGood())
                 {
                     LOG(Log::ERR) &lt;&lt; "While addJob(): " &lt;&lt; s.toString().toUtf8();
 				}
@@ -412,7 +412,7 @@ UaStatus SourceVariables_spawnIoJobRead (
 				pWriteValue
 				); 
 				UaStatus s = sourceVariableThreads-&gt;addJob (job);
-                if (!s.isGood)
+                if (!s.isGood())
                 {
                     LOG(Log::ERR) &lt;&lt; "While addJob(): " &lt;&lt; s.toString().toUtf8();
                 }

--- a/AddressSpace/designToSourceVariablesBody.xslt
+++ b/AddressSpace/designToSourceVariablesBody.xslt
@@ -351,8 +351,11 @@ UaStatus SourceVariables_spawnIoJobRead (
 				parentNode
 				); 
 				UaStatus s = sourceVariableThreads-&gt;addJob (job);
-                LOG(Log::WRN) &lt;&lt; s.toString().toUtf8();
-				</xsl:when>
+                if (!s.isGood)
+                {
+                    LOG(Log::ERR) &lt;&lt; "While addJob(): " &lt;&lt; s.toString().toUtf8();
+				}
+                </xsl:when>
 				<xsl:when test="@addressSpaceRead='synchronous'">
 				IoJob_<xsl:value-of select="$className"/>_READ_<xsl:value-of select="@name"/> job (
 				callback,
@@ -408,7 +411,11 @@ UaStatus SourceVariables_spawnIoJobRead (
 				parentNode,
 				pWriteValue
 				); 
-				sourceVariableThreads-&gt;addJob (job);
+				UaStatus s = sourceVariableThreads-&gt;addJob (job);
+                if (!s.isGood)
+                {
+                    LOG(Log::ERR) &lt;&lt; "While addJob(): " &lt;&lt; s.toString().toUtf8();
+                }
 				</xsl:when>
 				<xsl:when test="@addressSpaceWrite='synchronous'">
 				

--- a/AddressSpace/designToSourceVariablesHeader.xslt
+++ b/AddressSpace/designToSourceVariablesHeader.xslt
@@ -68,7 +68,8 @@ xsi:schemaLocation="http://www.w3.org/1999/XSL/Transform schema-for-xslt20.xsd "
 	</xsl:for-each>
 	};
 	
-	void SourceVariables_initSourceVariablesThreadPool (unsigned int minThreads=0, unsigned int maxThreads=10);
+	void SourceVariables_initSourceVariablesThreadPool (unsigned int minThreads=0, unsigned int maxThreads=10, unsigned int maxJobs=1000);
+    void SourceVariables_destroySourceVariablesThreadPool ();
 	
 	UaStatus SourceVariables_spawnIoJobRead (
 		ASSourceVariableJobId jobId,

--- a/Common/CMakeLists.txt
+++ b/Common/CMakeLists.txt
@@ -2,5 +2,5 @@
 
 add_library (Common OBJECT
 	src/ASUtils.cpp
-
+        src/QuasarThreadPool.cpp
 	)

--- a/Common/CMakeLists.txt
+++ b/Common/CMakeLists.txt
@@ -4,3 +4,23 @@ add_library (Common OBJECT
 	src/ASUtils.cpp
         src/QuasarThreadPool.cpp
 	)
+
+if (BUILD_QUASAR_TESTS)        
+link_directories(
+        ${OPCUA_TOOLKIT_PATH}/lib
+        ${BOOST_PATH_LIBS}
+        ${SERVER_LINK_DIRECTORIES}
+)       
+
+add_executable(test_quasar_threadpool
+        test/test_quasar_threadpool.cpp
+        $<TARGET_OBJECTS:Common>
+        $<TARGET_OBJECTS:LogIt>
+        
+        )
+ 
+        
+target_link_libraries( test_quasar_threadpool
+        ${OPCUA_TOOLKIT_LIBS_DEBUG}
+)
+endif(BUILD_QUASAR_TESTS)

--- a/Common/include/QuasarThreadPool.h
+++ b/Common/include/QuasarThreadPool.h
@@ -1,0 +1,55 @@
+/*
+ * QuasarThreadPool.h
+ *
+ *  Created on: 4 May 2018
+ *      Author: pnikiel
+ */
+
+#ifndef COMMON_INCLUDE_QUASARTHREADPOOL_H_
+#define COMMON_INCLUDE_QUASARTHREADPOOL_H_
+
+#include <mutex>
+#include <vector>
+#include <thread>
+#include <list>
+#include <condition_variable>
+
+#include <statuscode.h>
+
+namespace Quasar
+{
+
+class ThreadPoolJob
+{
+public:
+    virtual ~ThreadPoolJob() {};
+
+    virtual void execute() = 0;
+};
+
+class ThreadPool
+{
+public:
+    ThreadPool (unsigned int maxThreads, unsigned int maxJobs);
+    ~ThreadPool ();
+
+    UaStatus addJob (ThreadPoolJob* job);
+
+private:
+    void work();
+
+    std::mutex m_accessLock;
+    bool m_quit;
+    std::vector<std::thread> m_workers;
+    std::list<ThreadPoolJob*> m_pendingJobs;
+
+    const unsigned int m_maxJobs;
+
+    // this is the notification business for conditional variable notification
+    std::condition_variable m_conditionVariable;
+
+};
+
+}
+
+#endif /* COMMON_INCLUDE_QUASARTHREADPOOL_H_ */

--- a/Common/include/QuasarThreadPool.h
+++ b/Common/include/QuasarThreadPool.h
@@ -1,8 +1,22 @@
-/*
+/* © Copyright CERN, 2018.  All rights not expressly granted are reserved.
  * QuasarThreadPool.h
  *
  *  Created on: 4 May 2018
- *      Author: pnikiel
+ *      Author: Piotr Nikiel <piotr@nikiel.info>
+ *
+ *  This file is part of Quasar.
+ *
+ *  Quasar is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public Licence as published by
+ *  the Free Software Foundation, either version 3 of the Licence.
+ *
+ *  Quasar is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public Licence for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with Quasar.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 #ifndef COMMON_INCLUDE_QUASARTHREADPOOL_H_

--- a/Common/src/QuasarThreadPool.cpp
+++ b/Common/src/QuasarThreadPool.cpp
@@ -63,13 +63,15 @@ void ThreadPool::work()
 
 UaStatus ThreadPool::addJob (ThreadPoolJob* job)
 {
-    std::lock_guard<std::mutex>lock (m_accessLock);
-    if (m_pendingJobs.size() >= m_maxJobs)
     {
-        LOG(Log::ERR) << "The threadpool is already full, cant add new jobs. Enlarge the threadpool";
-        return OpcUa_BadResourceUnavailable;
+        std::lock_guard<std::mutex>lock (m_accessLock);
+        if (m_pendingJobs.size() >= m_maxJobs)
+        {
+            LOG(Log::ERR) << "The threadpool is already full, cant add new jobs. Enlarge the threadpool";
+            return OpcUa_BadResourceUnavailable;
+        }
+        m_pendingJobs.push_back(job);
     }
-    m_pendingJobs.push_back(job);
     m_conditionVariable.notify_one();
     LOG(Log::TRC) << "Added new job to threadpool, current number of jobs is:" << m_pendingJobs.size();
     return OpcUa_Good;

--- a/Common/src/QuasarThreadPool.cpp
+++ b/Common/src/QuasarThreadPool.cpp
@@ -1,0 +1,80 @@
+/*
+ * QuasarThreadPool.cpp
+ *
+ *  Created on: 4 May 2018
+ *      Author: pnikiel
+ */
+
+#include <algorithm>
+
+#include <QuasarThreadPool.h>
+#include <LogIt.h>
+
+namespace Quasar
+{
+
+ThreadPool::ThreadPool (unsigned int maxThreads, unsigned int maxJobs):
+        m_quit(false),
+        m_maxJobs(maxJobs)
+{
+    m_workers.reserve(maxThreads);
+    for (unsigned int i=0; i<maxThreads; ++i)
+        m_workers.emplace_back( [this](){this->work();} );
+}
+
+ThreadPool::~ThreadPool ()
+{
+    LOG(Log::TRC) << "Stopping threadpool";
+    m_quit = true;
+    m_conditionVariable.notify_all();
+    std::for_each( m_workers.begin(), m_workers.end(), [](std::thread &t){t.join();} );
+    LOG(Log::TRC) << "Stopped the threadpool";
+}
+
+void ThreadPool::work()
+{
+    while (!m_quit)
+    {
+        std::unique_lock<std::mutex>lock (m_accessLock);
+        if (m_pendingJobs.size()>0)
+        {
+            ThreadPoolJob *job = m_pendingJobs.front();
+            m_pendingJobs.pop_front();
+            unsigned int size = m_pendingJobs.size();
+            lock.unlock();
+            LOG(Log::TRC) << "Removed job from the threadpool, current number of jobs is:" << size;
+            try
+            {
+                job->execute();
+            }
+            catch (...)
+            {
+                LOG(Log::ERR) << "Job has thrown an unhandled exception.";
+            }
+
+            delete job;
+        }
+        else
+        {
+            m_conditionVariable.wait(lock);
+        }
+    }
+}
+
+UaStatus ThreadPool::addJob (ThreadPoolJob* job)
+{
+    std::lock_guard<std::mutex>lock (m_accessLock);
+    if (m_pendingJobs.size() >= m_maxJobs)
+    {
+        LOG(Log::ERR) << "The threadpool is already full, cant add new jobs. Enlarge the threadpool";
+        return OpcUa_BadResourceUnavailable;
+    }
+    m_pendingJobs.push_back(job);
+    m_conditionVariable.notify_one();
+    LOG(Log::TRC) << "Added new job to threadpool, current number of jobs is:" << m_pendingJobs.size();
+    return OpcUa_Good;
+}
+
+}
+
+

--- a/Common/src/QuasarThreadPool.cpp
+++ b/Common/src/QuasarThreadPool.cpp
@@ -1,8 +1,22 @@
-/*
+/* © Copyright CERN, 2018.  All rights not expressly granted are reserved.
  * QuasarThreadPool.cpp
  *
  *  Created on: 4 May 2018
- *      Author: pnikiel
+ *      Author: Piotr Nikiel <piotr@nikiel.info>
+ *
+ *  This file is part of Quasar.
+ *
+ *  Quasar is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public Licence as published by
+ *  the Free Software Foundation, either version 3 of the Licence.
+ *
+ *  Quasar is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public Licence for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with Quasar.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include <algorithm>

--- a/Common/test/test_quasar_threadpool.cpp
+++ b/Common/test/test_quasar_threadpool.cpp
@@ -1,0 +1,38 @@
+/*
+ * test_quasar_threadpool.cpp
+ *
+ *  Created on: 7 May 2018
+ *      Author: pnikiel
+ */
+
+
+#include <QuasarThreadPool.h>
+#include <iostream>
+
+#include <LogIt.h>
+
+
+
+class MyJob: public Quasar::ThreadPoolJob
+{
+public:
+    virtual void execute()
+    {
+        std::cout << "Starting job" << std::endl;
+        double x = M_PI;
+        for (unsigned int i=0; i<50E6; ++i)
+            x *= 1.00000001;
+        std::cout << "Finishing job, output=" << x << std::endl;
+    }
+};
+
+// check if the CPU load scales to 300% (if you have at least 3 cores)
+
+int main ()
+{
+    Log::initializeLogging(Log::WRN);
+    Quasar::ThreadPool threadPool (3, 1E6);
+    for (int i=0; i<100E3; ++i)
+        threadPool.addJob(new MyJob());
+    usleep(30E6);
+}

--- a/Design/Design.xsd
+++ b/Design/Design.xsd
@@ -400,6 +400,7 @@ elementFormDefault="qualified">
     			minOccurs="0" maxOccurs="unbounded">
     		</element>
     		<element name="returnvalue" type="tns:MethodReturnValue" minOccurs="0" maxOccurs="unbounded"></element>
+            <element name="documentation" type="tns:Documentation" maxOccurs="1" minOccurs="0"></element>
     	</sequence>
     	<attribute name="name" type="tns:VariableName" use="required"></attribute>
     </complexType>

--- a/FrameworkInternals/original_files.txt
+++ b/FrameworkInternals/original_files.txt
@@ -44,9 +44,11 @@ File CMakeLists.txt                         must_exist,must_be_versioned,install
 Directory Common/include install=create
 File ASUtils.h                              must_exist,must_be_versioned,md5=check,install=ask_to_merge 
 File Utils.h                                must_exist,must_be_versioned,install=ask_to_merge
+File QuasarThreadPool.h			    must_exist,must_be_versioned,md5=check,install=overwrite
 
 Directory Common/src install=create
-File ASUtils.cpp                            must_exist,must_be_versioned,md5=check,install=ask_to_merge 
+File ASUtils.cpp                            must_exist,must_be_versioned,md5=check,install=ask_to_merge
+File QuasarThreadPool.cpp		    must_exist,must_be_versioned,md5=check,install=overwrite
 
 Directory Configuration install=create
 File CMakeLists.txt                         must_exist,must_be_versioned, md5=check, install=overwrite

--- a/Server/src/BaseQuasarServer.cpp
+++ b/Server/src/BaseQuasarServer.cpp
@@ -70,6 +70,7 @@ BaseQuasarServer::BaseQuasarServer() :
 BaseQuasarServer::~BaseQuasarServer()
 {
     LOG(Log::TRC) << "Entered BaseQuasarServer dtr.";
+    AddressSpace::SourceVariables_destroySourceVariablesThreadPool ();
     shutdownEnvironment();
 }
 


### PR DESCRIPTION
There is an issue with UASDK ThreadPool: it has a fixed maximum task/thread factor of 4. This prevents some classes of applications, e.g. where a very big number of requests have to be accepted at one given moment. 

After a brief consideration of boost::asio threadpool, I rolled out this one. It is past initial tests where I managed to submit 50000 requests distributed into varied number of threads. Seems fine so far but will be additionally tested, of course.

What's missing: the maximum number of requests of source variables is not exposed in the config yet. So far hardcoded. Requires some changes of Meta.