### PR TITLE
Opcua 1056 improve memory management certificate

### DIFF
--- a/Meta/include/Certificate.h
+++ b/Meta/include/Certificate.h
@@ -23,8 +23,6 @@
 #include <openssl/x509_vfy.h>
 #include <openssl/asn1.h>
 
-using namespace std;
-
 /// load
 class Certificate {
 public:
@@ -42,17 +40,17 @@ public:
 	const static std::string DEFAULT_PUBLIC_CERT_FILENAME;
 	const static std::string DEFAULT_PRIVATE_CERT_FILENAME;
 
-	static Certificate* Instance( string certfn, string privkeyfn, enum behaviour_t beh );
+	static Certificate* Instance( std::string certfn, std::string privkeyfn, enum behaviour_t beh );
 	static Certificate* Instance( );
 
 	virtual ~Certificate();
 	int init( void );
-	string remainingTime( void );
+	std::string remainingTime( void );
 	void setTypeDER( void ) { m_type = SSL_FILETYPE_ASN1; }
 	void setTypePEM( void ) { m_type = SSL_FILETYPE_PEM; }
 
 private:
-	Certificate( string certfn, string privkeyfn, enum behaviour_t beh  );	// singleton
+	Certificate( std::string certfn, std::string privkeyfn, enum behaviour_t beh  );	// singleton
 	Certificate( Certificate const&);                            // copy constructor absent (i.e. cannot call it - linker will fail).
 	Certificate& operator=(Certificate const&);  		// assignment operator absent (i.e. cannot call it - linker will fail).
 	static Certificate* _pInstance;
@@ -75,8 +73,8 @@ private:
 	int validateCertificateFilename(const std::string& certificateFilename) const;
 	time_t _timeASN1toTIME_T( ASN1_TIME* time );
 
-	const string m_certfn;
-	const string m_privkeyfn;
+	const std::string m_certfn;
+	const std::string m_privkeyfn;
 	const behaviour_t m_behaviour;
 	int m_type;
 

--- a/Meta/include/Certificate.h
+++ b/Meta/include/Certificate.h
@@ -84,7 +84,8 @@ private:
 	std::time_t m_time_end;
 	status_t m_status;
 
-	int64_t m_remaining_validity_in_seconds;
+	 struct tm t;
+	 int64_t m_remaining_validity_in_seconds;
 };
 
 #endif /* META_SRC_CERTIFICATE_H_ */

--- a/Meta/src/Certificate.cpp
+++ b/Meta/src/Certificate.cpp
@@ -30,13 +30,14 @@ Certificate* Certificate::Instance( )
 {
 	if(!_pInstance)
 	{
-		LOG(Log::WRN) << "No Certfiicate singleton instance has been instantiated, programming error. Returning [NULL]";
+		LOG(Log::WRN) << "No Certificate singleton instance has been instantiated, programming error. Returning [NULL]";
 	}
 	return _pInstance;
 }
 
 Certificate::Certificate( string certfn, string privkeyfn, enum behaviour_t beh  )
-:m_certfn(certfn), m_privkeyfn(privkeyfn), m_behaviour(beh), m_ssl(NULL), m_time_end(NULL), m_status(STATUS_UNKNOWN), m_remaining_validity_in_seconds(0)
+:m_certfn(certfn), m_privkeyfn(privkeyfn), m_behaviour(beh), m_ssl(NULL), m_time_end(0), m_status(STATUS_UNKNOWN), m_remaining_validity_in_seconds(0)
+// :m_certfn(certfn), m_privkeyfn(privkeyfn), m_behaviour(beh), m_ssl(NULL), m_time_end(NULL), m_status(STATUS_UNKNOWN), m_remaining_validity_in_seconds(0)
 {
 	setTypeDER();
 
@@ -169,7 +170,7 @@ int Certificate::remainingSecs( void ) const
 // validity format is here:
 // https://github.com/openssl/openssl/commit/f48b83b4fb7d6689584cf25f61ca63a4891f5b11
 time_t Certificate::_timeASN1toTIME_T( ASN1_TIME* time ){
-	struct tm t;
+	// struct tm t;
 	string str = string( (const char *) time->data );
 	size_t i = 0;
 	/*

--- a/Meta/src/Certificate.cpp
+++ b/Meta/src/Certificate.cpp
@@ -5,6 +5,8 @@
  *      Author: mludwig
  */
 
+using namespace std;
+
 #include <iomanip>
 
 #include <Certificate.h>
@@ -30,7 +32,7 @@ Certificate* Certificate::Instance( )
 {
 	if(!_pInstance)
 	{
-		LOG(Log::WRN) << "No Certificate singleton instance has been instantiated, programming error. Returning [NULL]";
+		throw std::logic_error("No Certificate singleton instance has been instantiated, programming error.");
 	}
 	return _pInstance;
 }
@@ -169,9 +171,11 @@ int Certificate::remainingSecs( void ) const
 
 // validity format is here:
 // https://github.com/openssl/openssl/commit/f48b83b4fb7d6689584cf25f61ca63a4891f5b11
-time_t Certificate::_timeASN1toTIME_T( ASN1_TIME* time ){
-	// struct tm t;
-	string str = string( (const char *) time->data );
+time_t Certificate::_timeASN1toTIME_T( ASN1_TIME* time )
+{
+	struct tm t;
+	memset( (void*)&t, 0, sizeof t);
+	string str ( (const char *) time->data );
 	size_t i = 0;
 	/*
 	    OPCServerCertificate.cpp 150 str= 160822103554Z


### PR DESCRIPTION
1. Removes "using namespace" from the header not to pollute the namespace,
2. Fixes memory initialization by memset
3. Throws in case of logic error with Certificate::Instance rather than logs it (it would most likely trigger a null ptr exception or so)