### PR TITLE
OPCUA-1061 rename configurationhxx target

### DIFF
--- a/AddressSpace/CMakeLists.txt
+++ b/AddressSpace/CMakeLists.txt
@@ -42,4 +42,4 @@ add_library (AddressSpace OBJECT
 	
 
 add_custom_target(AddressSpaceGeneratedHeaders DEPENDS ${ADDRESSSPACE_HEADERS} include/ASInformationModel.h include/SourceVariables.h)
-add_dependencies (AddressSpace AddressSpaceGeneratedHeaders DeviceGeneratedHeaders Configuration.hxx)
+add_dependencies (AddressSpace AddressSpaceGeneratedHeaders DeviceGeneratedHeaders Configuration.hxx_GENERATED )

--- a/Configuration/CMakeLists.txt
+++ b/Configuration/CMakeLists.txt
@@ -30,7 +30,7 @@ add_custom_command(OUTPUT Configuration.cxx Configuration.hxx
 	DEPENDS Configuration.xsd
 )
 
-add_custom_target(Configuration.hxx DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Configuration.hxx)
+add_custom_target(Configuration.hxx_GENERATED DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Configuration.hxx)
 
 add_custom_command(OUTPUT Configurator.cpp	
 	WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}

--- a/Device/CMakeLists.txt
+++ b/Device/CMakeLists.txt
@@ -31,5 +31,5 @@ add_library (Device OBJECT
 	
 )
     
-add_dependencies (Device Configuration.hxx AddressSpaceGeneratedHeaders DeviceBase )
+add_dependencies (Device Configuration.hxx_GENERATED AddressSpaceGeneratedHeaders DeviceBase )
 

--- a/Documentation/ChangeLog.html
+++ b/Documentation/ChangeLog.html
@@ -28,9 +28,11 @@
 
 
 
+
               introduced</strong><br>
           </td>
           <td style="vertical-align: top; color: rgb(255, 255, 255);"><strong>Possible
+
 
 
 
@@ -52,7 +54,22 @@
 
 
 
+
               Release notes</strong><br>
+          </td>
+        </tr>
+        <tr>
+          <td valign="top">1.2.5<br>
+          </td>
+          <td valign="top"><br>
+          </td>
+          <td valign="top">The CMake target to generate
+            Configuration.hxx has been renamed to
+            Configuration.hxx_GENERATED .<br>
+            If you used this target e.g. for add_dependencies()
+            statement then you should follow the change accordingly.<br>
+          </td>
+          <td valign="top"><br>
           </td>
         </tr>
         <tr>

--- a/Meta/CMakeLists.txt
+++ b/Meta/CMakeLists.txt
@@ -20,4 +20,4 @@ file(GLOB META_SRCS src/*.cpp)
 
 add_library (Meta OBJECT ${META_SRCS})
 
-add_dependencies (Meta Configuration.hxx AddressSpace)
+add_dependencies (Meta Configuration.hxx_GENERATED AddressSpace)


### PR DESCRIPTION
The reason for such a change is that the target was named exactly as the file it generates (which was not the most optimal decision), and that confused "ninja" builder.