### PR TITLE
Implemented and tested

### DIFF
--- a/Device/designToDeviceBaseHeader.xslt
+++ b/Device/designToDeviceBaseHeader.xslt
@@ -115,6 +115,7 @@
 		<xsl:if test="fnc:classDeviceLogicHasMutex(/,$className)='true'">
 		void lock () { m_lock.lock(); }
 		void unlock () { m_lock.unlock(); }
+        boost::mutex &amp; getLock () { return m_lock; }
 		</xsl:if>
 		
 		/* variable-wise locks */


### PR DESCRIPTION
The reason of exposing device logic mutex (when it is declared in the Design of course) is to enable RAII-style constructs like:
std::lock_guard<decltype( getLock())> lock (getLock());