### PR TITLE
Fix python pip error in windows ci build

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ Once you've cloned the quasar framework git repository to your development machi
 
 CI build info | UA backend | CI build status
 ------------ | ------------- | -------------
-linux (travis-ci) | open62541 | ![travis-ci](https://travis-ci.org/quasar-team/quasar.svg?branch=master)
-windows (appveyor) | open62541 | ![Appveyor](https://ci.appveyor.com/api/projects/status/q8ruqgd2nj54b76p/branch/master?svg=true)
+linux (travis-ci) | open62541 | [![travis-ci](https://travis-ci.org/quasar-team/quasar.svg?branch=master)](https://travis-ci.org/quasar-team/quasar?branch=master)
+windows (appveyor) | open62541 | [![Appveyor](https://ci.appveyor.com/api/projects/status/q8ruqgd2nj54b76p/branch/master?svg=true)](https://ci.appveyor.com/project/ben-farnham/logit/branch/master)

--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ Once you've cloned the quasar framework git repository to your development machi
 CI build info | UA backend | CI build status
 ------------ | ------------- | -------------
 linux (travis-ci) | open62541 | [![travis-ci](https://travis-ci.org/quasar-team/quasar.svg?branch=master)](https://travis-ci.org/quasar-team/quasar?branch=master)
-windows (appveyor) | open62541 | [![Appveyor](https://ci.appveyor.com/api/projects/status/q8ruqgd2nj54b76p/branch/master?svg=true)](https://ci.appveyor.com/project/ben-farnham/logit/branch/master)
+windows (appveyor) | open62541 | [![Appveyor](https://ci.appveyor.com/api/projects/status/q8ruqgd2nj54b76p/branch/master?svg=true)](https://ci.appveyor.com/project/ben-farnham/quasar/branch/master)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,6 +70,7 @@ install:
 
   # python libraries
   - ps : Write-Output "Installing python packages..."
+  - ps : python -m pip install --upgrade pip
   - ps : python -m pip install lxml==3.6.0 # specific version is important
   - ps : python -m pip install pygit2
   - ps : Write-Output "Installed python packages"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,10 +46,10 @@ install:
 
   # nuget: package manager for installing libs
   - ps : Write-Output "Installing nuget packages to ${env:WINDOWS_DEPENDENCIES_DIR}"
-#  - ps : nuget install xercesc -NonInteractive -ExcludeVersion -OutputDirectory "${env:WINDOWS_DEPENDENCIES_DIR}"
-#  - ps : nuget install openssl-vc141-static-x86_64 -NonInteractive -ExcludeVersion -OutputDirectory "${env:WINDOWS_DEPENDENCIES_DIR}"
-#  - ps : nuget install boost-vc141 -Version 1.67.0 -NonInteractive -ExcludeVersion -OutputDirectory "${env:WINDOWS_DEPENDENCIES_DIR}"
-#  - ps : Write-Output "Installed nuget packages to ${env:WINDOWS_DEPENDENCIES_DIR}"
+  - ps : nuget install xercesc -NonInteractive -ExcludeVersion -OutputDirectory "${env:WINDOWS_DEPENDENCIES_DIR}"
+  - ps : nuget install openssl-vc141-static-x86_64 -NonInteractive -ExcludeVersion -OutputDirectory "${env:WINDOWS_DEPENDENCIES_DIR}"
+  - ps : nuget install boost-vc141 -Version 1.67.0 -NonInteractive -ExcludeVersion -OutputDirectory "${env:WINDOWS_DEPENDENCIES_DIR}"
+  - ps : Write-Output "Installed nuget packages to ${env:WINDOWS_DEPENDENCIES_DIR}"
 
   # code synthesis stuff has no managed package: manual install
   - ps : Write-Output "Installing xsdcxx..."

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,10 +46,10 @@ install:
 
   # nuget: package manager for installing libs
   - ps : Write-Output "Installing nuget packages to ${env:WINDOWS_DEPENDENCIES_DIR}"
-  - ps : nuget install xercesc -NonInteractive -ExcludeVersion -OutputDirectory "${env:WINDOWS_DEPENDENCIES_DIR}"
-  - ps : nuget install openssl-vc141-static-x86_64 -NonInteractive -ExcludeVersion -OutputDirectory "${env:WINDOWS_DEPENDENCIES_DIR}"
-  - ps : nuget install boost-vc141 -Version 1.67.0 -NonInteractive -ExcludeVersion -OutputDirectory "${env:WINDOWS_DEPENDENCIES_DIR}"
-  - ps : Write-Output "Installed nuget packages to ${env:WINDOWS_DEPENDENCIES_DIR}"
+#  - ps : nuget install xercesc -NonInteractive -ExcludeVersion -OutputDirectory "${env:WINDOWS_DEPENDENCIES_DIR}"
+#  - ps : nuget install openssl-vc141-static-x86_64 -NonInteractive -ExcludeVersion -OutputDirectory "${env:WINDOWS_DEPENDENCIES_DIR}"
+#  - ps : nuget install boost-vc141 -Version 1.67.0 -NonInteractive -ExcludeVersion -OutputDirectory "${env:WINDOWS_DEPENDENCIES_DIR}"
+#  - ps : Write-Output "Installed nuget packages to ${env:WINDOWS_DEPENDENCIES_DIR}"
 
   # code synthesis stuff has no managed package: manual install
   - ps : Write-Output "Installing xsdcxx..."


### PR DESCRIPTION
Strange. Apparently the CI build nodes used by quasar are (today) barfing on some old version of python pip. However, this was not a problem on Friday (when the quasar master branch built fine). Added a pip upgrade to the yml file.

Also added link to the appvyor/travis build for the master branch to the build badge displayed on the READMD.md