### PR TITLE
Fixed

### DIFF
--- a/Server/src/BaseQuasarServer.cpp
+++ b/Server/src/BaseQuasarServer.cpp
@@ -135,6 +135,8 @@ int BaseQuasarServer::serverRun(
 
     m_pServer->addNodeManager(m_nodeManager);
 
+    int serverReturnCode = 0;
+
     try
     {
         const int startServerReturn = m_pServer->start();
@@ -148,6 +150,7 @@ int BaseQuasarServer::serverRun(
     catch (const std::exception &e)
     {
         LOG(Log::ERR) << "Exception caught in BaseQuasarServer::serverRun:  [" << e.what() << "]";
+        serverReturnCode = 1;
     }
     AddressSpace::SourceVariables_destroySourceVariablesThreadPool ();
     shutdown();  // this is typically overridden by the developer
@@ -163,7 +166,7 @@ int BaseQuasarServer::serverRun(
         m_pServer = NULL;
     }
 
-    return 0;
+    return serverReturnCode;
 }
 
 std::string BaseQuasarServer::getApplicationPath() const


### PR DESCRIPTION
Best explained here:
2018-07-24 11:56.25.944552 [BaseQuasarServer.cpp:150, ERR] Exception caught in BaseQuasarServer::serverRun: [At /home/pnikiel/gitProjects/ScaOpcUa/ScaSoftware/Sca/SynchronousService.cpp:156 in std::vector<Sca::Reply> Sca::SynchronousService::SynchronousChannel::sendAndWaitReply(std::vector<Sca::Request>&, unsigned int) reply hasnt come]
2018-07-24 11:56.25.944696 [QuasarThreadPool.cpp:41, INF] Stopping threadpool - this might take some time.
2018-07-24 11:56.25.945569 [QuasarThreadPool.cpp:46, INF] Stopped the threadpool
2018-07-24 11:56.25.945679 [QuasarServer.cpp:85, INF] Shutting down Quasar server.
2018-07-24 11:56.25.946297 [Configurator.cpp:1119, INF] Total number of unlinked objects: 1
DRoot::unlinkAllChildren(): 0 objects unlinked
2018-07-24 11:56.25.986572 [BaseQuasarServer.cpp:93, INF] OpcServerMain() exited with code [0]
[pnikiel@pcatlnswfelix01 /home/pnikiel/gitProjects/ScaOpcUa/bin]$ echo $?
0