### PR TITLE
Merge-back the out-of-source

### DIFF
--- a/AddressSpace/CMakeLists.txt
+++ b/AddressSpace/CMakeLists.txt
@@ -16,19 +16,19 @@
 
 # Author: Piotr Nikiel <piotr@nikiel.info>
 
-include(cmake_generated.cmake)
+include(${PROJECT_BINARY_DIR}/AddressSpace/cmake_generated.cmake)
 
-	add_custom_command(OUTPUT include/ASInformationModel.h src/ASInformationModel.cpp
-	WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-	COMMAND ${PYTHON_COMMAND} quasar.py generate info_model
-	DEPENDS ${DESIGN_FILE} ${PROJECT_SOURCE_DIR}/AddressSpace/designToInformationModelHeader.xslt ${DESIGN_FILE} ${PROJECT_SOURCE_DIR}/AddressSpace/designToInformationModelBody.xslt 
-	)
-	
-	add_custom_command(OUTPUT src/SourceVariables.cpp include/SourceVariables.h
-	WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-	COMMAND ${PYTHON_COMMAND} quasar.py generate source_variables
-	DEPENDS ${DESIGN_FILE} ${PROJECT_SOURCE_DIR}/AddressSpace/designToSourceVariablesBody.xslt  ${PROJECT_SOURCE_DIR}/AddressSpace/designToSourceVariablesHeader.xslt DeviceBase
-	)
+add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/AddressSpace/include/ASInformationModel.h ${PROJECT_BINARY_DIR}/AddressSpace/src/ASInformationModel.cpp
+WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+COMMAND ${PYTHON_COMMAND} quasar.py generate info_model --project_binary_dir ${PROJECT_BINARY_DIR}
+DEPENDS ${DESIGN_FILE} ${PROJECT_SOURCE_DIR}/AddressSpace/designToInformationModelHeader.xslt ${DESIGN_FILE} ${PROJECT_SOURCE_DIR}/AddressSpace/designToInformationModelBody.xslt 
+)
+
+add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/AddressSpace/src/SourceVariables.cpp ${PROJECT_BINARY_DIR}/AddressSpace/include/SourceVariables.h
+WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+COMMAND ${PYTHON_COMMAND} quasar.py generate source_variables --project_binary_dir ${PROJECT_BINARY_DIR}
+DEPENDS ${DESIGN_FILE} ${PROJECT_SOURCE_DIR}/AddressSpace/designToSourceVariablesBody.xslt  ${PROJECT_SOURCE_DIR}/AddressSpace/designToSourceVariablesHeader.xslt DeviceBase
+)
 
 add_library (AddressSpace OBJECT
     src/ASInformationModel.cpp

--- a/AddressSpace/designToGeneratedCmakeAddressSpace.xslt
+++ b/AddressSpace/designToGeneratedCmakeAddressSpace.xslt
@@ -31,9 +31,9 @@ xsi:schemaLocation="http://www.w3.org/1999/XSL/Transform schema-for-xslt20.xsd "
 	<xsl:include href="../Design/CommonFunctions.xslt" />
 	<xsl:template name="commands">
 
-	add_custom_command(OUTPUT ${PROJECT_SOURCE_DIR}/AddressSpace/include/<xsl:value-of select="fnc:ASClassName(@name)"/>.h ${PROJECT_SOURCE_DIR}/AddressSpace/src/<xsl:value-of select="fnc:ASClassName(@name)"/>.cpp 
+	add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/AddressSpace/include/<xsl:value-of select="fnc:ASClassName(@name)"/>.h ${PROJECT_BINARY_DIR}/AddressSpace/src/<xsl:value-of select="fnc:ASClassName(@name)"/>.cpp 
 	WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-	COMMAND python quasar.py generate asclass <xsl:value-of select="@name"/>
+	COMMAND python quasar.py generate asclass <xsl:value-of select="@name"/> --project_binary_dir ${PROJECT_BINARY_DIR}
 	DEPENDS ${DESIGN_FILE} ${PROJECT_SOURCE_DIR}/AddressSpace/designToClassHeader.xslt ${PROJECT_SOURCE_DIR}/AddressSpace/designToClassBody.xslt Configuration.hxx_GENERATED validateDesign
 	)	
 	
@@ -47,13 +47,13 @@ xsi:schemaLocation="http://www.w3.org/1999/XSL/Transform schema-for-xslt20.xsd "
 	
 	set(ADDRESSSPACE_CLASSES 
 	<xsl:for-each select="/d:design/d:class">
-	src/<xsl:value-of select="fnc:ASClassName(@name)"/>.cpp
+	${PROJECT_BINARY_DIR}/AddressSpace/src/<xsl:value-of select="fnc:ASClassName(@name)"/>.cpp
 	</xsl:for-each>
 	)
 	
 	set(ADDRESSSPACE_HEADERS
 	<xsl:for-each select="/d:design/d:class">
-	include/<xsl:value-of select="fnc:ASClassName(@name)"/>.h
+	${PROJECT_BINARY_DIR}/AddressSpace/include/<xsl:value-of select="fnc:ASClassName(@name)"/>.h
 	</xsl:for-each>
 	)
 	

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,13 @@
 
 project(opc_ua)
 cmake_minimum_required(VERSION 2.8)
+
+if(NOT ${PROJECT_SOURCE_DIR} STREQUAL ${PROJECT_BINARY_DIR})
+message("Building out-of-source")
+message("PROJECT_SOURCE_DIR= ${PROJECT_SOURCE_DIR}")
+message("PROJECT_BINARY_DIR= ${PROJECT_BINARY_DIR}")
+endif()
+
 add_definitions(
 	-DSUPPORT_XML_CONFIG
 )
@@ -44,8 +51,9 @@ include_directories (
 	${OPCUA_TOOLKIT_PATH}/include/xmlparser
 	${OPCUA_TOOLKIT_PATH}/include/uapki
 	${BOOST_PATH_HEADERS}
-	${PROJECT_SOURCE_DIR}/Device/generated
-	${PROJECT_SOURCE_DIR}/Configuration
+	${PROJECT_BINARY_DIR}/Device/generated
+	${PROJECT_SOURCE_DIR}/Configuration  # this is to cover Configurator.h
+	${PROJECT_BINARY_DIR}/Configuration
 	${SERVER_INCLUDE_DIRECTORIES}
 	)
 
@@ -88,29 +96,40 @@ set(MODULES_OBJECTS)
 set(MODULE_INCLUDES)
 foreach(module ${SERVER_MODULES})
     FILE(GLOB SUBMODULE_INCLUDES ${PROJECT_SOURCE_DIR}/${module}/*/include)
-    set(MODULE_INCLUDES ${MODULE_INCLUDES} ${PROJECT_SOURCE_DIR}/${module}/include ${SUBMODULE_INCLUDES})
+    set(MODULE_INCLUDES ${MODULE_INCLUDES} ${PROJECT_SOURCE_DIR}/${module}/include ${PROJECT_BINARY_DIR}/${module}/include ${SUBMODULE_INCLUDES}) 
 endforeach(module)
 foreach(include ${MODULE_INCLUDES})
     include_directories(${include})
 endforeach(include)
 
 # add all module directories and add module objects
-foreach(module ${SERVER_MODULES})
+set(MODULES_IN_SOURCE_DIR ${NATIVE_SERVER_MODULES} ${CUSTOM_SERVER_MODULES})
+foreach(module ${MODULES_IN_SOURCE_DIR})
     add_subdirectory( ${module} )
-	set(MODULES_OBJECTS ${MODULES_OBJECTS} $<TARGET_OBJECTS:${module}>)
+    set(MODULES_OBJECTS ${MODULES_OBJECTS} $<TARGET_OBJECTS:${module}>)
+endforeach(module)
+
+foreach(module ${OPTIONAL_SERVER_MODULES})    
+    add_subdirectory( ${PROJECT_BINARY_DIR}/${module} ${PROJECT_BINARY_DIR}/${module} )  # listed twice, 1st is SOURCE_DIR 2nd is BINARY_DIR
+    set(MODULES_OBJECTS ${MODULES_OBJECTS} $<TARGET_OBJECTS:${module}>)
 endforeach(module)
 
 
-add_custom_command(
-    OUTPUT ${PROJECT_SOURCE_DIR}/Design/validated.tmp
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/Design
-    COMMAND ${PYTHON_COMMAND} ${PROJECT_SOURCE_DIR}/quasar.py validate_design
-    COMMAND ${CMAKE_COMMAND} -E touch ${PROJECT_SOURCE_DIR}/Design/validated.tmp
-    DEPENDS ${DESIGN_FILE} ${PROJECT_SOURCE_DIR}/Design/Design.xsd
-    )
-add_custom_target(validateDesign DEPENDS  ${PROJECT_SOURCE_DIR}/Design/validated.tmp )
 
-add_custom_target(dep ALL COMMAND ${PROJECT_SOURCE_DIR}/quasar.py design_vs_device )
+
+add_custom_command(
+    OUTPUT ${PROJECT_BINARY_DIR}/Design/validated.tmp
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    COMMAND ${PYTHON_COMMAND} ${PROJECT_SOURCE_DIR}/quasar.py validate_design --project_binary_dir ${PROJECT_BINARY_DIR}
+    COMMAND ${CMAKE_COMMAND} -E touch ${PROJECT_BINARY_DIR}/Design/validated.tmp
+    DEPENDS ${DESIGN_FILE}  ${PROJECT_SOURCE_DIR}/Design/Design.xsd
+    )
+add_custom_target(validateDesign DEPENDS  ${PROJECT_BINARY_DIR}/Design/validated.tmp )
+
+add_custom_target(dep ALL 
+        COMMAND ${PROJECT_SOURCE_DIR}/quasar.py design_vs_device 
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        ) 
 
 link_directories(
 	${OPCUA_TOOLKIT_PATH}/lib
@@ -135,3 +154,8 @@ target_link_libraries ( ${EXECUTABLE}
 	${QUASAR_SERVER_LIBS}
 	${SERVER_LINK_LIBRARIES}
 )
+
+if(EXISTS ${PROJECT_SOURCE_DIR}/CMakeEpilogue.cmake)
+	  MESSAGE("CMakeEpilogue found")
+	  include (${PROJECT_SOURCE_DIR}/CMakeEpilogue.cmake)
+endif(EXISTS ${PROJECT_SOURCE_DIR}/CMakeEpilogue.cmake)

--- a/Configuration/CMakeLists.txt
+++ b/Configuration/CMakeLists.txt
@@ -18,29 +18,29 @@
 
 MESSAGE( STATUS "Design file=" ${DESIGN_FILE} )
 
-add_custom_command(OUTPUT Configuration.xsd
+add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/Configuration/Configuration.xsd
 	WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-	COMMAND ${PYTHON_COMMAND} quasar.py generate config_xsd
+	COMMAND ${PYTHON_COMMAND} quasar.py generate config_xsd --project_binary_dir ${PROJECT_BINARY_DIR}
 	DEPENDS ${DESIGN_FILE} designToConfigurationXSD.xslt validateDesign ${PROJECT_SOURCE_DIR}/quasar.py
 	)
 
-add_custom_command(OUTPUT Configuration.cxx Configuration.hxx
+add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/Configuration/Configuration.cxx ${PROJECT_BINARY_DIR}/Configuration/Configuration.hxx
 	WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/Configuration
-	COMMAND xsdcxx cxx-tree  --generate-serialization --namespace-map http://cern.ch/quasar/Configuration=Configuration  Configuration.xsd
-	DEPENDS Configuration.xsd
+	COMMAND xsdcxx cxx-tree  --generate-serialization --namespace-map http://cern.ch/quasar/Configuration=Configuration --output-dir ${PROJECT_BINARY_DIR}/Configuration ${PROJECT_BINARY_DIR}/Configuration/Configuration.xsd  
+	DEPENDS ${PROJECT_BINARY_DIR}/Configuration/Configuration.xsd
 )
 
-add_custom_target(Configuration.hxx_GENERATED DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Configuration.hxx)
+add_custom_target(Configuration.hxx_GENERATED DEPENDS ${PROJECT_BINARY_DIR}/Configuration/Configuration.hxx )
 
-add_custom_command(OUTPUT Configurator.cpp	
+add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/Configuration/Configurator.cpp	
 	WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-	COMMAND ${PYTHON_COMMAND} quasar.py generate config_cpp
+	COMMAND ${PYTHON_COMMAND} quasar.py generate config_cpp --project_binary_dir ${PROJECT_BINARY_DIR}
 	DEPENDS ${DESIGN_FILE} designToConfigurator.xslt ${PROJECT_SOURCE_DIR}/quasar.py AddressSpace Device
 )
 
-add_custom_command(OUTPUT ConfigValidator.cpp	
+add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/Configuration/ConfigValidator.cpp	
 	WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-	COMMAND ${PYTHON_COMMAND} quasar.py generate config_validator
+	COMMAND ${PYTHON_COMMAND} quasar.py generate config_validator --project_binary_dir ${PROJECT_BINARY_DIR}
 	DEPENDS ${DESIGN_FILE} designToConfigValidator.xslt ${PROJECT_SOURCE_DIR}/quasar.py AddressSpace Device
 )
 

--- a/Configuration/designToConfigurationXSD.xslt
+++ b/Configuration/designToConfigurationXSD.xslt
@@ -27,6 +27,7 @@ xmlns:d="http://cern.ch/quasar/Design"
 xmlns:fnc="http://cern.ch/quasar/Functions"
 xsi:schemaLocation="http://www.w3.org/1999/XSL/Transform schema-for-xslt20.xsd ">
 	<xsl:output indent="yes" method="xml"/>
+	<xsl:param name="metaXsdPath"/>
 	
 <xsl:function name="fnc:dataTypeToXsdType">
 	<xsl:param name="dataType"/>	
@@ -172,7 +173,7 @@ xsi:schemaLocation="http://www.w3.org/1999/XSL/Transform schema-for-xslt20.xsd "
 	xmlns:xi="http://www.w3.org/2003/XInclude"
 	elementFormDefault="qualified">
 	
-	<xi:include href="../Meta/config/Meta.xsd" xpointer="xmlns(xs=http://www.w3.org/2001/XMLSchema) xpointer(/xs:schema/node())">
+	<xi:include href="{$metaXsdPath}" xpointer="xmlns(xs=http://www.w3.org/2001/XMLSchema) xpointer(/xs:schema/node())">
 	</xi:include>
 	
 	<xs:simpleType name="ObjectName">

--- a/Device/CMakeLists.txt
+++ b/Device/CMakeLists.txt
@@ -16,7 +16,7 @@
 
 # Author: Piotr Nikiel <piotr@nikiel.info>
 
-include(${PROJECT_BINARY_DIR}/generated/cmake_header.cmake)
+include(${PROJECT_BINARY_DIR}/Device/generated/cmake_header.cmake)
 
 add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/Device/include/DRoot.h ${PROJECT_BINARY_DIR}/Device/src/DRoot.cpp
 WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}

--- a/Device/CMakeLists.txt
+++ b/Device/CMakeLists.txt
@@ -16,7 +16,7 @@
 
 # Author: Piotr Nikiel <piotr@nikiel.info>
 
-include(generated/cmake_header.cmake)
+include(${PROJECT_BINARY_DIR}/generated/cmake_header.cmake)
 
 add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/Device/include/DRoot.h ${PROJECT_BINARY_DIR}/Device/src/DRoot.cpp
 WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}

--- a/Device/CMakeLists.txt
+++ b/Device/CMakeLists.txt
@@ -18,6 +18,12 @@
 
 include(generated/cmake_header.cmake)
 
+add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/Device/include/DRoot.h ${PROJECT_BINARY_DIR}/Device/src/DRoot.cpp
+WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+COMMAND python quasar.py generate root --project_binary_dir ${PROJECT_BINARY_DIR}
+DEPENDS ${DESIGN_FILE} ${PROJECT_SOURCE_DIR}/quasar.py validateDesign designToRootHeader.xslt designToRootBody.xslt
+)
+
 add_library (Device OBJECT
 
     ${DEVICEBASE_GENERATED_FILES}

--- a/Device/designToGeneratedCmakeDevice.xslt
+++ b/Device/designToGeneratedCmakeDevice.xslt
@@ -31,9 +31,9 @@ xsi:schemaLocation="http://www.w3.org/1999/XSL/Transform schema-for-xslt20.xsd "
 	<xsl:include href="../Design/CommonFunctions.xslt" />
 	<xsl:template name="commands">
 	
-	add_custom_command(OUTPUT ${PROJECT_SOURCE_DIR}/Device/generated/<xsl:value-of select="fnc:Base_DClassName(@name)"/>.h ${PROJECT_SOURCE_DIR}/Device/generated/<xsl:value-of select="fnc:Base_DClassName(@name)"/>.cpp 
+	add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/Device/generated/<xsl:value-of select="fnc:Base_DClassName(@name)"/>.h ${PROJECT_BINARY_DIR}/Device/generated/<xsl:value-of select="fnc:Base_DClassName(@name)"/>.cpp 
 	WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-	COMMAND python quasar.py generate base <xsl:value-of select="@name"/>
+	COMMAND python quasar.py generate base <xsl:value-of select="@name"/> --project_binary_dir ${PROJECT_BINARY_DIR}
 	DEPENDS ${DESIGN_FILE} ${PROJECT_SOURCE_DIR}/quasar.py ${PROJECT_SOURCE_DIR}/Device/designToDeviceBaseHeader.xslt Configuration.hxx_GENERATED validateDesign ${PROJECT_SOURCE_DIR}/Device/designToDeviceBaseBody.xslt
 	)	
 	
@@ -46,11 +46,7 @@ xsi:schemaLocation="http://www.w3.org/1999/XSL/Transform schema-for-xslt20.xsd "
 	
 	<xsl:template match="/">
 	
-	add_custom_command(OUTPUT include/DRoot.h src/DRoot.cpp
-	WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-	COMMAND python quasar.py generate root
-	DEPENDS ${DESIGN_FILE} ${PROJECT_SOURCE_DIR}/quasar.py validateDesign designToRootHeader.xslt designToRootBody.xslt
-	)
+
 	
 	<xsl:for-each select="/d:design/d:class">
 	<xsl:call-template name="commands"/>

--- a/FrameworkInternals/configurationGenerators.py
+++ b/FrameworkInternals/configurationGenerators.py
@@ -26,9 +26,8 @@ from commandMap import getCommand
   
 def generateConfiguration(context):
     """Generates the file Configuration.xsd. This method is called automatically by cmake, it does not need to be called by the user."""
-    transformByKey( TransformKeys.CONFIGURATION_XSD, {'context':context} )
-    print("Calling xmllint to process XInclude ")
+    transformByKey( TransformKeys.CONFIGURATION_XSD, {'context':context, 'metaXsdPath':os.path.join(context['projectSourceDir'],'Meta','config','Meta.xsd')} )
     subprocessWithImprovedErrorsPipeOutputToFile(
-        [getCommand("xmllint"), "--xinclude", getTransformOutput(TransformKeys.CONFIGURATION_XSD)], 
-        os.path.join('Configuration','Configuration.xsd'), 
+        [getCommand("xmllint"), "--xinclude", getTransformOutput(TransformKeys.CONFIGURATION_XSD, {'context':context})], 
+        os.path.join(context['projectBinaryDir'],'Configuration','Configuration.xsd'), 
         getCommand("xmllint"))

--- a/FrameworkInternals/configurationGenerators.py
+++ b/FrameworkInternals/configurationGenerators.py
@@ -26,7 +26,9 @@ from commandMap import getCommand
   
 def generateConfiguration(context):
     """Generates the file Configuration.xsd. This method is called automatically by cmake, it does not need to be called by the user."""
-    transformByKey( TransformKeys.CONFIGURATION_XSD, {'context':context, 'metaXsdPath':os.path.join(context['projectSourceDir'],'Meta','config','Meta.xsd')} )
+    transformByKey( TransformKeys.CONFIGURATION_XSD, {
+        'context':context,
+        'metaXsdPath':os.path.join(context['projectSourceDir'],'Meta','config','Meta.xsd').replace('\\','/') } )
     subprocessWithImprovedErrorsPipeOutputToFile(
         [getCommand("xmllint"), "--xinclude", getTransformOutput(TransformKeys.CONFIGURATION_XSD, {'context':context})], 
         os.path.join(context['projectBinaryDir'],'Configuration','Configuration.xsd'), 

--- a/FrameworkInternals/externalToolCheck.py
+++ b/FrameworkInternals/externalToolCheck.py
@@ -124,10 +124,14 @@ def subprocessWithImprovedErrorsPipeOutputToFile(subprocessCommand, outputFile, 
 
 	Keyword arguments:
 	subprocessCommand -- String or list of strings that will be given to subprocess
-	dependencyName -- parameterless name of the command, just for error loging purposes
-	outputFile -- file where the std out of the process will be written into
-	validReturnCodes -- array of acceptable return codes, only 0 by default. If the return code is not in the list and exception will be thrown
+	dependencyName    -- parameterless name of the command, just for error loging purposes
+	outputFile        -- file where the std out of the process will be written into
+	validReturnCodes  -- array of acceptable return codes, only 0 by default. If the return code is not in the list and exception will be thrown
 	"""
+	print 'Calling {tool} with args {args} with output to file {out}'.format(
+		tool=dependencyName,
+		args=' '.join(subprocessCommand),
+		out=outputFile)
 	try:
 		with open(outputFile,"wb") as out:
 			process = subprocess.Popen(subprocessCommand, stdout=out)
@@ -138,4 +142,4 @@ def subprocessWithImprovedErrorsPipeOutputToFile(subprocessCommand, outputFile, 
 	except Exception, e:
 		raise Exception("There was an application error when trying to execute the program [" + dependencyName + "]. Exception: [" + str(e) + "]")
 	if returnCode not in validReturnCodes:
-		raise Exception("Application returned bad return code when trying to execute the program [" + dependencyName + "]. Return code: [" + str(returnCode) + "]")
+		raise WrongReturnValue(dependencyName, returnCode)

--- a/FrameworkInternals/generateCmake.py
+++ b/FrameworkInternals/generateCmake.py
@@ -25,6 +25,7 @@ import platform
 from transformDesign import TransformKeys, transformByKey
 from externalToolCheck import subprocessWithImprovedErrors
 from commandMap import getCommand
+from quasarExceptions import Mistake
 
 def generateCmake(context, buildType="Release"):
 	"""Generates CMake header lists in various directories, and then calls cmake.
@@ -32,6 +33,13 @@ def generateCmake(context, buildType="Release"):
 	Keyword arguments:
 	buildType -- Optional parameter to specify Debug or Release build. If it is not specified it will default to Release.
 	"""	
+	if not context['projectSourceDir'] == context['projectBinaryDir']: # out-of-source build
+		if os.path.isfile(os.path.join(context['projectSourceDir'], 'CMakeCache.txt')):
+			raise Mistake('User mistake? CMakeCache.txt exists in source directory; '+
+						  'that will prevent CMake to make a successful out-of-source build. '+
+						  'Remove CMakeCache.txt (or attempt "quasar.py clean" and retry') 
+		
+		
 	transformByKey(TransformKeys.AS_CMAKE, {'context':context})
 	transformByKey(TransformKeys.D_CMAKE, {'context':context})
 	print("Build type ["+buildType+"]")

--- a/FrameworkInternals/generateCmake.py
+++ b/FrameworkInternals/generateCmake.py
@@ -35,13 +35,19 @@ def generateCmake(context, buildType="Release"):
 	transformByKey(TransformKeys.AS_CMAKE, {'context':context})
 	transformByKey(TransformKeys.D_CMAKE, {'context':context})
 	print("Build type ["+buildType+"]")
+	projectSourceDir = context['projectSourceDir']
+	projectBinaryDir = context['projectBinaryDir']
+	if not os.path.isdir(projectBinaryDir):
+		print("PROJECT_BINARY_DIR {0} doesn't exist -- creating it.".format(projectBinaryDir))
+		os.mkdir(projectBinaryDir)
+	os.chdir(projectBinaryDir)
 
 	print("Calling CMake")
 	if platform.system() == "Windows":
 		subprocessWithImprovedErrors([getCommand("cmake"), "-DCMAKE_BUILD_TYPE=" + buildType,
-					      "-G", "Visual Studio 15 2017 Win64", "."],
+					      "-G", "Visual Studio 15 2017 Win64", projectSourceDir],
 					     getCommand("cmake"))
 	elif platform.system() == "Linux":
 		subprocessWithImprovedErrors([getCommand("cmake"), "-DCMAKE_BUILD_TYPE=" + buildType,
-                                              "."],
+                                              projectSourceDir],
 					     getCommand("cmake"))

--- a/FrameworkInternals/quasarExceptions.py
+++ b/FrameworkInternals/quasarExceptions.py
@@ -28,3 +28,7 @@ class WrongReturnValue(Exception):
 			tool=tool, 
 			rv=str(return_value)
 			))
+		
+class Mistake(Exception):
+	def __init__(self, desc):
+		Exception.__init__(self, desc)

--- a/FrameworkInternals/transformDesign.py
+++ b/FrameworkInternals/transformDesign.py
@@ -76,7 +76,7 @@ QuasarTransforms = [
     [TransformKeys.AS_INFOMODEL_H,          'AddressSpace/designToInformationModelHeader.xslt',     'AddressSpace/include/ASInformationModel.h',    'B',            True,           False,        None],
     [TransformKeys.AS_INFOMODEL_CPP,        'AddressSpace/designToInformationModelBody.xslt',       'AddressSpace/src/ASInformationModel.cpp',      'B',            True,           False,        None],
     [TransformKeys.AS_CMAKE,                'AddressSpace/designToGeneratedCmakeAddressSpace.xslt', 'AddressSpace/cmake_generated.cmake',           'B',            False,          False,        None],
-    [TransformKeys.CONFIGURATION_XSD,       'Configuration/designToConfigurationXSD.xslt',          'Configuration/Configuration-noxinclude.xsd',   'B',            False,          False,        None],
+    [TransformKeys.CONFIGURATION_XSD,       'Configuration/designToConfigurationXSD.xslt',          'Configuration/Configuration-noxinclude.xsd',   'B',            False,          False,        'metaXsdPath={metaXsdPath}'],
     [TransformKeys.CONFIGURATOR,            'Configuration/designToConfigurator.xslt',              'Configuration/Configurator.cpp',               'B',            True,           False,        None],
     [TransformKeys.CONFIG_VALIDATOR,        'Configuration/designToConfigValidator.xslt',           'Configuration/ConfigValidator.cpp',            'B',            True,           False,        None],
     [TransformKeys.DESIGN_VALIDATION,       'Design/designValidation.xslt',                         'Design/validationOutput.removeme',             'B',            False,          False,        None],
@@ -153,7 +153,11 @@ def getTransformSpecByKey(key):
     return filter(lambda x: x[FieldIds.KEY.value]==key, QuasarTransforms)[0]
 
 def getTransformOutput (key, supplementaryData={}):
-    return getTransformSpecByKey(key)[FieldIds.OUT_PATH.value].format(**supplementaryData)
+    """Returns absolute path to the output of transform identified by key 'key'"""
+    transformSpec = getTransformSpecByKey(key)
+    outputDir = supplementaryData['context']['projectBinaryDir'] if transformSpec[FieldIds.SOURCE_OR_BINARY.value] == 'B' else supplementaryData['context']['projectSourceDir']
+    outputFileRaw = transformSpec[FieldIds.OUT_PATH.value].format(**supplementaryData)
+    return os.path.join(outputDir, outputFileRaw)
     
 def transformByKey (keys, supplementaryData={}):
     """ Works both for a single key as well as a list of keys """
@@ -163,7 +167,7 @@ def transformByKey (keys, supplementaryData={}):
     else:           
         transformSpec = getTransformSpecByKey(keys)
         outputDir = supplementaryData['context']['projectBinaryDir'] if transformSpec[FieldIds.SOURCE_OR_BINARY.value] == 'B' else supplementaryData['context']['projectSourceDir']
-        outputFile = os.path.join(outputDir, getTransformOutput(keys, supplementaryData))
+        outputFile = getTransformOutput(keys, supplementaryData)
         transformDesignVerbose(
             xsltTransformation = transformSpec[FieldIds.XSLT_PATH.value], 
             outputFile = outputFile, 

--- a/quasar.py
+++ b/quasar.py
@@ -26,14 +26,8 @@ import subprocess
 import inspect
 import webbrowser
 
-internalFolders = ["AddressSpace", "Configuration", "Design", "Device", "FrameworkInternals", "Server", "LogIt", "Meta"]
-initialDir = os.getcwd()
-splittedPath = initialDir.split(os.path.sep)
-splittedPathLength = len(splittedPath)
-currentFolder = splittedPath[splittedPathLength - 1]
-if(currentFolder in internalFolders):
-	os.chdir("../")
-sys.path.insert(0, './FrameworkInternals')
+this_script_path = os.path.abspath(sys.argv[0])
+sys.path.insert(0, os.path.join(os.path.dirname(this_script_path), 'FrameworkInternals'))
 
 from quasarCommands import printCommandList
 from quasarCommands import getCommands, extract_common_arguments
@@ -51,7 +45,7 @@ def makeContext():
 	* projectBinaryDirectory
 	etc ... """
 	context = {}
-	context['projectSourceDir'] = os.getcwd()  # TODO: port the "this_script" logic from Yocto branch 
+	context['projectSourceDir'] = os.path.dirname(this_script_path)
 	context['projectBinaryDir'] = project_binary_dir  
 	return context
 

--- a/quasar.py
+++ b/quasar.py
@@ -31,7 +31,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(this_script_path), 'FrameworkInt
 
 from quasarCommands import printCommandList
 from quasarCommands import getCommands, extract_common_arguments
-from quasarExceptions import WrongReturnValue, WrongArguments
+from quasarExceptions import WrongReturnValue, WrongArguments, Mistake
 
 # args starts from the command name (e.g. 'build') and skips the common arguments (e.g. 'project_binary_dir')
 (args, project_binary_dir) = extract_common_arguments(sys.argv[1:])  # 1: to skip the script name given by the operating system
@@ -78,5 +78,5 @@ else:
 			callee( makeContext(), *args )  # pack arguments after the last chunk of the command	
 		else:
 			callee( *args )						
-	except (WrongReturnValue, WrongArguments) as e:
+	except (WrongReturnValue, WrongArguments, Mistake) as e:
 		print str(e)


### PR DESCRIPTION
This is the full-featured out-of-source build capability.
The last PR #61 equipped individual quasar generators to understand --project_binary_dir, this PR benefits from it via update CMake statements.

The end-user advantage is that they can do:

./quasar build --project_binary_dir   <somewhere>

and given quasar server should be build in <somewhere> without polluting the source directory.