### PR TITLE
Implemented OPCUA-1131 range(bounds)-based config restrictions

### DIFF
--- a/Configuration/designToConfigDocumentationHtml.xslt
+++ b/Configuration/designToConfigDocumentationHtml.xslt
@@ -7,6 +7,17 @@ xmlns:fnc="http://cern.ch/quasar/Functions"
 xsi:schemaLocation="http://www.w3.org/1999/XSL/Transform schema-for-xslt20.xsd ">
     <xsl:output indent="yes" method="xml"/>
     
+    <xsl:function name="fnc:boundRestrictionTypeToSymbol">
+    <xsl:param name="restrictionType"/>
+    <xsl:choose>
+    <xsl:when test="$restrictionType='minExclusive'">&gt;</xsl:when>
+    <xsl:when test="$restrictionType='minInclusive'">&gt;=</xsl:when>
+    <xsl:when test="$restrictionType='maxInclusive'">&lt;=</xsl:when>
+    <xsl:when test="$restrictionType='maxExclusive'">&lt;</xsl:when>
+    <xsl:otherwise><xsl:message terminate="yes">Type unsupported: <xsl:value-of select="$restrictionType"/></xsl:message></xsl:otherwise>
+    </xsl:choose>
+    </xsl:function>
+    
     <xsl:template match="/">
     
     <html>
@@ -49,6 +60,20 @@ xsi:schemaLocation="http://www.w3.org/1999/XSL/Transform schema-for-xslt20.xsd "
                         Enumeration: 
                         <xsl:for-each select="d:configRestriction/d:restrictionByEnumeration/d:enumerationValue">
                             <code><xsl:value-of select="@value"/></code><xsl:if test="position() &lt; count(../d:enumerationValue)">|</xsl:if>
+                        </xsl:for-each>
+                    </xsl:if>
+                    <xsl:if test="d:configRestriction/d:restrictionByBounds">
+                        <br/>
+                        Bounds:
+                        <xsl:variable name="fieldName"><xsl:value-of select="@name"/></xsl:variable>
+                        <xsl:for-each select="d:configRestriction/d:restrictionByBounds/@*">
+                            <xsl:sort select="name()" order="descending" />
+                            <code>
+                            <xsl:if test="position() > 1"> AND </xsl:if>
+                            <xsl:value-of select="$fieldName"/>
+                            <xsl:value-of select="fnc:boundRestrictionTypeToSymbol(name())"/>
+                            <xsl:value-of select="."/>
+                            </code>
                         </xsl:for-each>
                     </xsl:if>
                     </div>

--- a/Configuration/designToConfigurationXSD.xslt
+++ b/Configuration/designToConfigurationXSD.xslt
@@ -70,6 +70,20 @@ xsi:schemaLocation="http://www.w3.org/1999/XSL/Transform schema-for-xslt20.xsd "
                 </xsl:attribute>
                 </xsl:element>
             </xsl:for-each>
+            <xsl:for-each select="d:configRestriction/d:restrictionByBounds">
+                <xsl:if test="@minInclusive">
+                    <xs:minInclusive value="{@minInclusive}"/>
+                </xsl:if>
+                <xsl:if test="@maxInclusive">
+                    <xs:maxInclusive value="{@maxInclusive}"/>
+                </xsl:if>
+                <xsl:if test="@minExclusive">
+                    <xs:minExclusive value="{@minExclusive}"/>
+                </xsl:if>
+                <xsl:if test="@maxExclusive">
+                    <xs:maxExclusive value="{@maxExclusive}"/>
+                </xsl:if>
+            </xsl:for-each>
         </xsl:element>
     </xsl:element>
 </xsl:template>

--- a/Design/Design.xsd
+++ b/Design/Design.xsd
@@ -431,6 +431,7 @@ elementFormDefault="qualified">
         <all>
             <element name="restrictionByPattern" type="tns:RestrictionByPattern" maxOccurs="1" minOccurs="0"></element>
             <element name="restrictionByEnumeration" type="tns:RestrictionByEnumeration" minOccurs="0" maxOccurs="1"></element>
+            <element name="restrictionByBounds" type="tns:RestrictionByBounds" minOccurs="0" maxOccurs="1"></element>
         </all>
     </complexType>
 
@@ -447,4 +448,12 @@ elementFormDefault="qualified">
     <complexType name="EnumerationValue">
         <attribute name="value" type="string" use="required"></attribute>
     </complexType>
+
+    <complexType name="RestrictionByBounds">
+        <attribute name="minExclusive" type="double" use="optional"/>
+        <attribute name="minInclusive" type="double" use="optional"/>
+        <attribute name="maxExclusive" type="double" use="optional"/>
+        <attribute name="maxInclusive" type="double" use="optional"/>
+    </complexType>
+    
 </schema>

--- a/FrameworkInternals/configurationGenerators.py
+++ b/FrameworkInternals/configurationGenerators.py
@@ -25,11 +25,17 @@ from externalToolCheck import subprocessWithImprovedErrorsPipeOutputToFile
 from commandMap import getCommand
   
 def generateConfiguration(context):
-    """Generates the file Configuration.xsd. This method is called automatically by cmake, it does not need to be called by the user."""
-    transformByKey( TransformKeys.CONFIGURATION_XSD, {
-        'context':context,
-        'metaXsdPath':os.path.join(context['projectSourceDir'],'Meta','config','Meta.xsd').replace('\\','/') } )
-    subprocessWithImprovedErrorsPipeOutputToFile(
-        [getCommand("xmllint"), "--xinclude", getTransformOutput(TransformKeys.CONFIGURATION_XSD, {'context':context})], 
-        os.path.join(context['projectBinaryDir'],'Configuration','Configuration.xsd'), 
-        getCommand("xmllint"))
+	"""Generates the file Configuration.xsd. This method is called automatically by cmake, it does not need to be called by the user."""
+	config_xsd_path = os.path.join(context['projectBinaryDir'],'Configuration','Configuration.xsd')
+	try: 
+		transformByKey( TransformKeys.CONFIGURATION_XSD, {
+			'context':context,
+			'metaXsdPath':os.path.join(context['projectSourceDir'],'Meta','config','Meta.xsd').replace('\\','/') } )
+	except:	
+		if os.path.isfile(config_xsd_path):
+			os.remove(config_xsd_path)
+		raise
+	subprocessWithImprovedErrorsPipeOutputToFile(
+		[getCommand("xmllint"), "--xinclude", getTransformOutput(TransformKeys.CONFIGURATION_XSD, {'context':context})], 
+		config_xsd_path, 
+		getCommand("xmllint"))

--- a/quasar.py
+++ b/quasar.py
@@ -80,3 +80,4 @@ else:
 			callee( *args )						
 	except (WrongReturnValue, WrongArguments, Mistake) as e:
 		print str(e)
+		sys.exit(1)


### PR DESCRIPTION
Adds possibility to restrict numerical config entries (and config-initialized cache-vars) by min/max (either inclusive or exclusive).