### PR TITLE
Fixes for API changes in open62541 0.3

### DIFF
--- a/Server/include/opcserver_open62541.h
+++ b/Server/include/opcserver_open62541.h
@@ -40,8 +40,12 @@ private:
     ASNodeManager *m_nodemanager;
     std::string m_logFilePath;
 
+    #if UA_OPEN62541_VER_MINOR == 2
     UA_ServerConfig m_server_config;
     UA_ServerNetworkLayer m_server_network_layer;
+    #else
+    UA_ServerConfig* m_server_config;
+    #endif
     UA_Server *m_server;
     boost::thread m_open62541_server_thread;
 

--- a/Server/src/opcserver_open62541.cpp
+++ b/Server/src/opcserver_open62541.cpp
@@ -14,8 +14,12 @@ using namespace std;
 
 OpcServer::OpcServer():
     m_nodemanager(0),
+    #if UA_OPEN62541_VER_MINOR == 2
     m_server_config(UA_ServerConfig_standard),
     m_server_network_layer(UA_ServerNetworkLayerTCP(UA_ConnectionConfig_standard, 4841)),
+    #else
+    m_server_config(nullptr),
+    #endif
     m_server(0)
 {
     //NOTE: UA_Server created later because it needs configuration (which is supplied later)
@@ -32,10 +36,17 @@ int OpcServer::setServerConfig(const UaString& configurationFile, const UaString
     LOG(Log::INF) << "Note: with open62541 backend, there isn't (yet) XML configuration loading. Assuming hardcoded server settings (endpoint's port, etc.)";
     // NOTE: some basid settings are configured in ctr init list
     // TODO: XML config reading
+
+    #if UA_OPEN62541_VER_MINOR == 2
     m_server_config = UA_ServerConfig_standard;
     m_server_network_layer = UA_ServerNetworkLayerTCP(UA_ConnectionConfig_standard, 4841);
     m_server_config.networkLayers = &m_server_network_layer;
     m_server_config.networkLayersSize = 1;
+    #else
+    m_server_config = UA_ServerConfig_new_minimal(4841, /*certificate*/ nullptr);
+    #endif
+
+
     return 0;
 }
 


### PR DESCRIPTION
A tiny part of open62541 API is used directly in quasar sources, this part adapts for the API changes between 0.2 and 0.3.
The code is ifdefed depending on open62541 defined version with the intent of moving entirely to 0.3 in foreseeable future.