### PR TITLE
Implemented shared object creation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,12 +148,6 @@ add_executable ( ${EXECUTABLE}
 	)
 set_target_properties( ${EXECUTABLE} PROPERTIES RUNTIME_OUTPUT_DIRECTORY bin/ )
 
-if(BUILD_SERVER_SHARED_LIB)
-        set( SERVER_SHARED_LIB_TARGET "${EXECUTABLE}Object" )
-        add_library ( ${SERVER_SHARED_LIB_TARGET} SHARED ${MODULES_OBJECTS} )
-        set_target_properties( ${SERVER_SHARED_LIB_TARGET} PROPERTIES LIBRARY_OUTPUT_DIRECTORY bin/ )
-endif(BUILD_SERVER_SHARED_LIB)
-
 set(TARGET_LIBS
         ${BOOST_LIBS}
         ${XML_LIBS}
@@ -165,7 +159,10 @@ set(TARGET_LIBS
 target_link_libraries ( ${EXECUTABLE} ${TARGET_LIBS} )
 
 if(BUILD_SERVER_SHARED_LIB)
-        target_link_libraries( ${SERVER_SHARED_LIB_TARGET} ${TARGET_LIBS})
+        set( SERVER_SHARED_LIB_TARGET "${EXECUTABLE}Object" )
+        add_library ( ${SERVER_SHARED_LIB_TARGET} SHARED ${MODULES_OBJECTS} )
+        set_target_properties( ${SERVER_SHARED_LIB_TARGET} PROPERTIES LIBRARY_OUTPUT_DIRECTORY bin/ )
+	target_link_libraries( ${SERVER_SHARED_LIB_TARGET} ${TARGET_LIBS})
 endif(BUILD_SERVER_SHARED_LIB)
 
 if(EXISTS ${PROJECT_SOURCE_DIR}/CMakeEpilogue.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,13 +148,25 @@ add_executable ( ${EXECUTABLE}
 	)
 set_target_properties( ${EXECUTABLE} PROPERTIES RUNTIME_OUTPUT_DIRECTORY bin/ )
 
-target_link_libraries ( ${EXECUTABLE}
-	${BOOST_LIBS}
-	${XML_LIBS}
-	${OPCUA_TOOLKIT_LIBS}
-	${QUASAR_SERVER_LIBS}
-	${SERVER_LINK_LIBRARIES}
-)
+if(BUILD_SERVER_SHARED_LIB)
+        set( SERVER_SHARED_LIB_TARGET "${EXECUTABLE}Object" )
+        add_library ( ${SERVER_SHARED_LIB_TARGET} SHARED ${MODULES_OBJECTS} )
+        set_target_properties( ${SERVER_SHARED_LIB_TARGET} PROPERTIES LIBRARY_OUTPUT_DIRECTORY bin/ )
+endif(BUILD_SERVER_SHARED_LIB)
+
+set(TARGET_LIBS
+        ${BOOST_LIBS}
+        ${XML_LIBS}
+        ${OPCUA_TOOLKIT_LIBS}
+        ${QUASAR_SERVER_LIBS}
+        ${SERVER_LINK_LIBRARIES}
+        )
+
+target_link_libraries ( ${EXECUTABLE} ${TARGET_LIBS} )
+
+if(BUILD_SERVER_SHARED_LIB)
+        target_link_libraries( ${SERVER_SHARED_LIB_TARGET} ${TARGET_LIBS})
+endif(BUILD_SERVER_SHARED_LIB)
 
 if(EXISTS ${PROJECT_SOURCE_DIR}/CMakeEpilogue.cmake)
 	  MESSAGE("CMakeEpilogue found")

--- a/ProjectSettings.cmake
+++ b/ProjectSettings.cmake
@@ -3,3 +3,6 @@ set(EXECUTABLE OpcUaServer)
 set(SERVER_INCLUDE_DIRECTORIES  )
 set(SERVER_LINK_LIBRARIES  )
 set(SERVER_LINK_DIRECTORIES  )
+
+# If ON, in addition to an executable, a shared object will be created.
+set(BUILD_SERVER_SHARED_LIB OFF)


### PR DESCRIPTION
The motivation to this is to have an option to build a (complete) quasar-based server as a shared object. This is required to load it, run it (and do data exchange with it) from a higher-level programming language like Python or so. 