### PR TITLE
Appveyor build fix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -74,7 +74,7 @@ install:
   # python libraries
   - ps : Write-Output "Installing python packages..."
   - ps : python -m pip install --upgrade pip
-  - ps : python -m pip install lxml==3.6.0 # specific version is important, THIS LINE IS BREAKING THE BUILD
+  - ps : python -W ignore -m pip install lxml==3.6.0 # specific version is important, THIS LINE IS BREAKING THE BUILD
   - ps : python -m pip install pygit2
   - ps : python -m pip install enum34
   - ps : Write-Output "Installed python packages"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -74,9 +74,9 @@ install:
   # python libraries
   - ps : Write-Output "Installing python packages..."
   - ps : python -m pip install --upgrade pip
-  - ps : python -W ignore -m pip install lxml==3.6.0 # specific version is important, THIS LINE IS BREAKING THE BUILD
-  - ps : python -m pip install pygit2
-  - ps : python -m pip install enum34
+  - ps : python -W ignore -m pip install lxml==3.6.0 # specific version is important
+  - ps : python -W ignore -m pip install pygit2
+  - ps : python -W ignore -m pip install enum34
   - ps : Write-Output "Installed python packages"
   - ps : python C:\workspace\OPC-UA\quasar\FrameworkInternals\manage_files.py # checks to see if required python libs are OK.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -74,7 +74,7 @@ install:
   # python libraries
   - ps : Write-Output "Installing python packages..."
   - ps : python -m pip install --upgrade pip
-  - ps : python -m pip install lxml==3.6.0 # specific version is important
+  - ps : python -m pip install lxml==3.6.0 # specific version is important, THIS LINE IS BREAKING THE BUILD
   - ps : python -m pip install pygit2
   - ps : python -m pip install enum34
   - ps : Write-Output "Installed python packages"


### PR DESCRIPTION
Hum, not a fix per-se. More of a patch. Enough to get us past the current CI build blocker.

The long term solution is to move away from the vagaries of machine provisioning on appveyor on every build (the source of most of our problems) to a more stable windows build platform in the form of a windows docker image. That's a work in progress (it's quite a lot harder than I'd thought - much harder than linux images).

I'd suggest merging this to master, it should keep the CI build running for now.