### PR TITLE
Implemented better handling when Variant is Null;

### DIFF
--- a/CalculatedVariables/src/CalculatedVariablesChangeListener.cpp
+++ b/CalculatedVariables/src/CalculatedVariablesChangeListener.cpp
@@ -45,6 +45,13 @@ void CalculatedVariables::ChangeListener::operator ()(
     else if (newValue.value())
     {
         UaVariant variant (*newValue.value());
+        if (variant.isEmpty())
+        {
+            LOG(Log::DBG, logComponentId) << "Variant empty, probably storing NULL.";
+            m_variable.setValue(0, ParserVariable::State::Bad);
+        }
+        else
+        {
         OpcUa_Double value;
         if (variant.toDouble(value) == OpcUa_Good)
             {
@@ -55,6 +62,7 @@ void CalculatedVariables::ChangeListener::operator ()(
         {
                 LOG(Log::WRN, logComponentId) << "didnt manage to convert the value to double";
                 m_variable.setValue(0, ParserVariable::State::Bad);
+            }
         }
     }
     else


### PR DESCRIPTION
This is relevant to all situations when a calc var is created on a hardware-polled value which can be NULL e.g. because of connectivity malfunction or so. In such a case WRN was too much for a log level.