### PR TITLE
Made m_addressSpaceLink private

### DIFF
--- a/Device/designToDeviceBaseBody.xslt
+++ b/Device/designToDeviceBaseBody.xslt
@@ -45,7 +45,15 @@ xsi:schemaLocation="http://www.w3.org/1999/XSL/Transform schema-for-xslt20.xsd "
 			else
 				m_addressSpaceLink = addressSpaceLink;	
 			m_stringAddress.assign( stringAddress );
-		}
+			}
+
+			AddressSpace::<xsl:value-of select="fnc:ASClassName($className)"/> * <xsl:value-of select="fnc:Base_DClassName(@name)"/>::getAddressSpaceLink () const
+			{
+			if (m_addressSpaceLink)
+			return m_addressSpaceLink;
+			else
+			throw std::logic_error("m_addressSpaceLink is nullptr! at:"+m_stringAddress);
+			}
 		
 		/* add/remove */
 		<xsl:for-each select="d:hasobjects">

--- a/Device/designToDeviceBaseHeader.xslt
+++ b/Device/designToDeviceBaseHeader.xslt
@@ -70,7 +70,7 @@
 
 
 		void linkAddressSpace (AddressSpace::<xsl:value-of select="fnc:ASClassName($className)" /> * as, const std::string &amp; stringAddress);
-		AddressSpace::<xsl:value-of select="fnc:ASClassName($className)"/> * getAddressSpaceLink () const { return m_addressSpaceLink; }
+		AddressSpace::<xsl:value-of select="fnc:ASClassName($className)"/> * getAddressSpaceLink () const; 
 		
 		
 		/* find methods for children */
@@ -151,14 +151,11 @@
 		
 		Parent_<xsl:value-of select="fnc:DClassName($className)"/> * m_parent;
 	
-		public:	  // TODO: reconsider this! shoudln't be public!
 		AddressSpace::
 		<xsl:value-of select="fnc:ASClassName($className)" />
 		*m_addressSpaceLink;
 		
 
-
-		private:
 		std::string m_stringAddress;
 		<xsl:for-each select="d:hasobjects">
 		std::vector &lt; <xsl:value-of select="fnc:DClassName(@class)"/> * &gt; m_<xsl:value-of select="@class"/>s;


### PR DESCRIPTION
This was planned for ages...
Device classes should use getAddressSpaceLink() instead of m_addressSpaceLink,
this is especially important for code that gets executed at init or at destruction (especially if that code was spawned from an extra thread) because the risk of nullptr dereference is minimized.