### PR TITLE
Opcua 1623 quasar fails to compile in c++17 mode

### DIFF
--- a/Configuration/CMakeLists.txt
+++ b/Configuration/CMakeLists.txt
@@ -26,7 +26,7 @@ add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/Configuration/Configuration.xsd
 
 add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/Configuration/Configuration.cxx ${PROJECT_BINARY_DIR}/Configuration/Configuration.hxx
 	WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/Configuration
-	COMMAND xsdcxx cxx-tree  --generate-serialization --namespace-map http://cern.ch/quasar/Configuration=Configuration --output-dir ${PROJECT_BINARY_DIR}/Configuration ${PROJECT_BINARY_DIR}/Configuration/Configuration.xsd  
+	COMMAND xsdcxx cxx-tree --std c++11 --generate-serialization --namespace-map http://cern.ch/quasar/Configuration=Configuration --output-dir ${PROJECT_BINARY_DIR}/Configuration ${PROJECT_BINARY_DIR}/Configuration/Configuration.xsd  
 	DEPENDS ${PROJECT_BINARY_DIR}/Configuration/Configuration.xsd
 )
 

--- a/Configuration/designToConfigurator.xslt
+++ b/Configuration/designToConfigurator.xslt
@@ -305,7 +305,7 @@ xsi:schemaLocation="http://www.w3.org/1999/XSL/Transform schema-for-xslt20.xsd "
 	bool configure (std::string fileName, AddressSpace::ASNodeManager *nm, ConfigXmlDecoratorFunction configXmlDecoratorFunction)
     {
 	
-	std::auto_ptr&lt;Configuration::Configuration&gt; theConfiguration;
+	std::unique_ptr&lt;Configuration::Configuration&gt; theConfiguration;
 	
 	try
 	{


### PR DESCRIPTION
Adding manual defines does not seem necessary as passing correct options to xsd-cxx places the defintion in the respective header.