### PR TITLE
meta_build_info, problem of escaping toolkit_libs

### DIFF
--- a/Meta/CMakeLists.txt
+++ b/Meta/CMakeLists.txt
@@ -51,11 +51,13 @@ add_custom_target(runBuildInfoGeneratorPy ALL
 	DEPENDS alwaysRunBuildInfoGeneratorPy
 )
 
+string(REPLACE "-l" "_l" OPCUA_TOOLKIT_LIBS_ESCAPED ${OPCUA_TOOLKIT_LIBS})
+
 add_custom_command(OUTPUT alwaysRunBuildInfoGeneratorPy # note output never actually created: ensures cmd always runs
 	COMMENT "generating meta build info definitions header using python script" 
 	WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
 	DEPENDS ${CMAKE_CURRENT_LIST_DIR}/../FrameworkInternals/meta_build_info.py
-	COMMAND python ${CMAKE_CURRENT_LIST_DIR}/../FrameworkInternals/meta_build_info.py --project_root_dir ${CMAKE_SOURCE_DIR} --target_generation_dir ${PROJECT_BINARY_DIR}/generated --toolkit_libs "${OPCUA_TOOLKIT_LIBS}"
+	COMMAND python ${CMAKE_CURRENT_LIST_DIR}/../FrameworkInternals/meta_build_info.py --project_root_dir ${CMAKE_SOURCE_DIR} --target_generation_dir ${PROJECT_BINARY_DIR}/generated --toolkit_libs "${OPCUA_TOOLKIT_LIBS_ESCAPED}"
 	VERBATIM
 )
 


### PR DESCRIPTION
The problem we're solving is that in my case OPCUA_LIBS are (in CMake): -lrt -lpthread, that is, no static or dynamic lib as that is no longer necessary.

So they get passed as

meta_build_info.py --project_root_dir /tmp/check_bundled_open62541 --target_generation_dir /tmp/check_bundled_open62541/build/generated --toolkit_libs -lrt;-lpthread

where -lrt is read as an argument to python and not as an argument that was/would be used for the linker.
 You can try yourself, it is easy to reproduce.

I propose to replace -l by _l, I know -- quite weak -- for the moment works but for sure will break one day. Maybe we can do this improvement now and then you contribute sth better in near future?