### PR TITLE
simplified cert, provide example code for handling .ua cert store

### DIFF
--- a/Meta/include/Certificate.h
+++ b/Meta/include/Certificate.h
@@ -26,21 +26,12 @@
 /// load
 class Certificate {
 public:
-    /// behavior:
-    /// NONE: don't attempt to read any certificates, do nothing. Validity is unknown.
-    /// TRY:  if cert file exists, load it, otherwise report and continue
-    /// TRYCA: like TRY, but with CA and a chain
-    /// CERT: load a crt from file, abort if problem
-    /// CERTCA: like CERT, but with CA load and interrogation
-	/// we can discuss this ;-)
-	enum behaviour_t { BEHAVIOR_NONE, BEHAVIOR_TRY, BEHAVIOR_TRYCA, BEHAVIOR_CERT, BEHAVIOR_CERTCA };
-
 	enum status_t { STATUS_OK, STATUS_FAILED, STATUS_UNKNOWN };
 
 	const static std::string DEFAULT_PUBLIC_CERT_FILENAME;
 	const static std::string DEFAULT_PRIVATE_CERT_FILENAME;
 
-	static Certificate* Instance( std::string certfn, std::string privkeyfn, enum behaviour_t beh );
+	static Certificate* Instance( std::vector<string> vder );
 	static Certificate* Instance( );
 
 	virtual ~Certificate();
@@ -50,7 +41,7 @@ public:
 	void setTypePEM( void ) { m_type = SSL_FILETYPE_PEM; }
 
 private:
-	Certificate( std::string certfn, std::string privkeyfn, enum behaviour_t beh  );	// singleton
+	Certificate( std::vector<string> vder );	// singleton
 	Certificate( Certificate const&);                            // copy constructor absent (i.e. cannot call it - linker will fail).
 	Certificate& operator=(Certificate const&);  		// assignment operator absent (i.e. cannot call it - linker will fail).
 	static Certificate* _pInstance;
@@ -75,7 +66,6 @@ private:
 
 	const std::string m_certfn;
 	const std::string m_privkeyfn;
-	const behaviour_t m_behaviour;
 	int m_type;
 
 	SSL *m_ssl;

--- a/Meta/include/MetaUtils.h
+++ b/Meta/include/MetaUtils.h
@@ -47,6 +47,8 @@ void linkHandlerObjectAndAddressSpaceNode(THandlerObject* handlerObject, TAddres
 void setDServer(Device::DServer*);
 
 std::string calculateRemainingCertificateValidity(void);
+std::vector<std::string> readCertAndPkeyFilenameFromServerConfig(void);
+
 
 
 } // namespace MetaUtils

--- a/Meta/src/meta.cpp
+++ b/Meta/src/meta.cpp
@@ -191,8 +191,15 @@ void configureServer(const Configuration::Server& config, AddressSpace::ASNodeMa
     MetaUtils::linkHandlerObjectAndAddressSpaceNode(dServer, asServer);
     MetaUtils::setDServer(dServer);
 
-    //pnikiel: temporary disabled as per OPCUA-1564 due to planned work on OPCUA-1541
-    //dServer->updateRemainingCertificateValidity(MetaUtils::calculateRemainingCertificateValidity());
+    // pnikiel: temporary disabled as per OPCUA-1564 due to planned work on OPCUA-1541
+    // ml: keep disabled as discussed on 17 dec 2019 in atlas dcm meeting, where we essentially
+    // decided that security is the server developers responsibility and presently neither
+    // quasar nor atlas sysadmins are ready to do full security (like it should be, if you do it at all).
+    // The code stays disabled therefore since quasar does not implement it actively, but
+    // since it is working the code remains here, as dead code for your example. Works only
+    // for .ua anyway, and not for .open6.
+    //
+    // dServer->updateRemainingCertificateValidity(MetaUtils::calculateRemainingCertificateValidity());
 }
 
 void configureComponentLogLevel(const Log::LogComponentHandle& componentHandle, const string& logLevel, AddressSpace::ASNodeManager *nm, AddressSpace::ASComponentLogLevels* parent)


### PR DESCRIPTION
as discussed yesterday:
- simplified cert (a certificate (der) & private key (pem) ) behavior
- provide example code for handling .ua cert store, 
- handle only first endpoint cert,
- keep calls to class Certificate disabled in meta.cpp
- keep dragging dead code as example, to help server developer to implement at own initiative
- only relevant to .ua toolkit, open6 does not handle certs anyway for now in quasar
- builds for .ua and .open6, no further tests