### PR TITLE
defaults for SourceVariableThreadPool taken directly from the configu…

### DIFF
--- a/Configuration/CMakeLists.txt
+++ b/Configuration/CMakeLists.txt
@@ -21,7 +21,7 @@ MESSAGE( STATUS "Design file=" ${DESIGN_FILE} )
 add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/Configuration/Configuration.xsd
 	WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
 	COMMAND ${PYTHON_COMMAND} quasar.py generate config_xsd --project_binary_dir ${PROJECT_BINARY_DIR}
-	DEPENDS ${DESIGN_FILE} designToConfigurationXSD.xslt validateDesign ${PROJECT_SOURCE_DIR}/quasar.py
+	DEPENDS ${DESIGN_FILE} designToConfigurationXSD.xslt validateDesign ${PROJECT_SOURCE_DIR}/quasar.py ${PROJECT_SOURCE_DIR}/Meta/config/Meta.xsd
 	)
 
 add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/Configuration/Configuration.cxx ${PROJECT_BINARY_DIR}/Configuration/Configuration.hxx

--- a/Meta/config/Meta.xsd
+++ b/Meta/config/Meta.xsd
@@ -59,9 +59,9 @@
 	</xs:complexType>
 	
     <xs:complexType name="SourceVariableThreadPool">
-      <xs:attribute name="minThreads" use="required" type="xs:unsignedInt"/>
-      <xs:attribute name="maxThreads" use="required" type="xs:unsignedInt"/>
-      <xs:attribute name="maxJobs" use="required" type="xs:unsignedInt"/>
+      <xs:attribute name="minThreads" use="optional" type="xs:unsignedInt" default="1" />
+      <xs:attribute name="maxThreads" use="optional" type="xs:unsignedInt" default="10" />
+      <xs:attribute name="maxJobs" use="optional" type="xs:unsignedInt" default="1000" />
    </xs:complexType>   
 
 	<xs:simpleType name="logLevelIdentifier">

--- a/Meta/src/meta.cpp
+++ b/Meta/src/meta.cpp
@@ -227,10 +227,7 @@ const Configuration::SourceVariableThreadPool getSourceVariableThreadPoolConfig(
 	else
 	{
 		LOG(Log::INF) << "no StandardMetaData.SourceVariableThreadPool configuration found in the configuration file, configuring StandardMetaData.SourceVariableThreadPool with default values";
-		unsigned int min = 1;
-		unsigned int max = 10;
-		unsigned int jobs = 1000;
-		return Configuration::SourceVariableThreadPool(min, max, jobs);
+		return Configuration::SourceVariableThreadPool();
 	}
 }
 


### PR DESCRIPTION
…ration schema

the advantage is that it is more unified and similar to how remaining config defaults are done, and that schema-aware editors can profit from it.