### PR TITLE
use image docker.io/bfarnham/quasar:quasar-open62541

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jobs:
   include:
     - name: open62541_default_quasar_design
       script:
-        - docker run  --interactive --tty bfarnham/quasar:quasar-open62541-next /bin/bash -c "
+        - docker run  --interactive --tty bfarnham/quasar:quasar-open62541 /bin/bash -c "
             echo '********************************************************************' ;
             echo branch ${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} ;
             echo '********************************************************************' ;
@@ -19,7 +19,7 @@ jobs:
 
     - name: open62541_test_cache_variables
       script:
-        - docker run  --interactive --tty bfarnham/quasar:quasar-open62541-next /bin/bash -c "
+        - docker run  --interactive --tty bfarnham/quasar:quasar-open62541 /bin/bash -c "
             echo '********************************************************************' ;
             echo branch ${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} ;
             echo '********************************************************************' ;
@@ -36,7 +36,7 @@ jobs:
 
     - name: open62541_test_methods
       script:
-        - docker run  --interactive --tty bfarnham/quasar:quasar-open62541-next /bin/bash -c "
+        - docker run  --interactive --tty bfarnham/quasar:quasar-open62541 /bin/bash -c "
             echo '********************************************************************' ;
             echo branch ${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} ;
             echo '********************************************************************' ;


### PR DESCRIPTION
Last part of OPCUA-2005. Had updated the images and pushed tagged image to docker.io, but then forgot to retag at docker.io with 'quasar-open62541'.

Now fixed docker.io tag (so latest CI image is 'quasar-open62541'), which requires these changes in the travis yml file