### PR TITLE
Opcua 2176 detect too old astyle

### DIFF
--- a/FrameworkInternals/transformDesign.py
+++ b/FrameworkInternals/transformDesign.py
@@ -108,8 +108,12 @@ def run_indent_tool(unindented_content, fout):
        fout - a file object to which the output will be written"""
     try:
         astyle_version_check_process = subprocess.run(['astyle', '--version'],
-                                                    stderr=subprocess.PIPE, check=True)
-        astyle_version_text = astyle_version_check_process.stderr.decode('utf-8')
+                                                          stderr=subprocess.PIPE,
+                                                          stdout=subprocess.PIPE,
+                                                          check=True)
+        # note to line below: whether version is printed in stdout or stderr unfortunately depends
+        # on astyle version ... ironic ;-)
+        astyle_version_text = astyle_version_check_process.stderr.decode('utf-8') + astyle_version_check_process.stdout.decode('utf-8')
         if 'Artistic Style Version 3' not in astyle_version_text:
             raise Exception(('Found astyle with incompatible version. Astyle versions prior to 3 '
                              'are known to have a bug which makes them impossible to use with '

--- a/FrameworkInternals/transformDesign.py
+++ b/FrameworkInternals/transformDesign.py
@@ -109,11 +109,12 @@ def run_indent_tool(unindented_content, fout):
     try:
         astyle_version_check_process = subprocess.run(['astyle', '--version'],
                                                     stdout=subprocess.PIPE, check=True)
-        if 'Artistic Style Version 3' not in astyle_version_check_process.stdout:
+        astyle_version_text = astyle_version_check_process.stdout.decode('utf-8')
+        if 'Artistic Style Version 3' not in astyle_version_text:
             raise Exception(('Found astyle with incompatible version. Astyle versions prior to 3 '
                              'are known to have a bug which makes them impossible to use with '
                              'quasar. The version string returned was: '
-                             f'{astyle_version_check_process.stdout}'))
+                             f'{astyle_version_text}'))
         completed_indenter_process = subprocess.run(['astyle'], input=unindented_content,
                                                     stdout=subprocess.PIPE, check=True)
     except FileNotFoundError:

--- a/FrameworkInternals/transformDesign.py
+++ b/FrameworkInternals/transformDesign.py
@@ -108,8 +108,8 @@ def run_indent_tool(unindented_content, fout):
        fout - a file object to which the output will be written"""
     try:
         astyle_version_check_process = subprocess.run(['astyle', '--version'],
-                                                    stdout=subprocess.PIPE, check=True)
-        astyle_version_text = astyle_version_check_process.stdout.decode('utf-8')
+                                                    stderr=subprocess.PIPE, check=True)
+        astyle_version_text = astyle_version_check_process.stderr.decode('utf-8')
         if 'Artistic Style Version 3' not in astyle_version_text:
             raise Exception(('Found astyle with incompatible version. Astyle versions prior to 3 '
                              'are known to have a bug which makes them impossible to use with '

--- a/FrameworkInternals/transformDesign.py
+++ b/FrameworkInternals/transformDesign.py
@@ -107,6 +107,13 @@ def run_indent_tool(unindented_content, fout):
        unindented_content - stream of bytes (e.g. encoded string) to pass to the tool,
        fout - a file object to which the output will be written"""
     try:
+        astyle_version_check_process = subprocess.run(['astyle', '--version'],
+                                                    stdout=subprocess.PIPE, check=True)
+        if 'Artistic Style Version 3' not in astyle_version_check_process.stdout:
+            raise Exception(('Found astyle with incompatible version. Astyle versions prior to 3 '
+                             'are known to have a bug which makes them impossible to use with '
+                             'quasar. The version string returned was: '
+                             f'{astyle_version_check_process.stdout}'))
         completed_indenter_process = subprocess.run(['astyle'], input=unindented_content,
                                                     stdout=subprocess.PIPE, check=True)
     except FileNotFoundError:


### PR DESCRIPTION
Who wants a coup d'oeil on it?

CI results:
test name                                | ret code | time spent [s] 
---------------------------------------- + -------- + ---------------
open62541_default_quasar_design          |        0 |             136
open62541_test_recurrent_hasobjects      |        0 |             137
open62541_test_cache_variables           |        0 |             212
open62541_test_single_variable_node      |        0 |             137
open62541_test_methods                   |        0 |             139
open62541_test_instantiation_from_design |        0 |             124
open62541_test_config_entries            |        0 |             136
open62541_test_config_restrictions       |        0 |             136
uasdk_default_quasar_design              |        0 |              85
uasdk_test_sync_methods                  |        0 |             100
uasdk_test_async_methods                 |        0 |             111
uasdk_test_config_entries                |        0 |              86
uasdk_test_cache_variables               |        0 |             202
uasdk_test_source_variables              |        0 |             125
