### PR TITLE
fix for missing library

### DIFF
--- a/AddressSpace/include/ArrayTools.h
+++ b/AddressSpace/include/ArrayTools.h
@@ -23,6 +23,7 @@
 #define QUASAR_COMMON_SRC_ARRAYUTILS_H_
 
 #include <vector>
+#include <string>
 #include <uavariant.h>
 
 namespace AddressSpace


### PR DESCRIPTION
ArrayTools error when compiling with newer g++