### PR TITLE
OPCUA-3229 fixed code gen for all parent/child combinations of devicelogic

### DIFF
--- a/Device/templates/designToDeviceBaseHeader.jinja
+++ b/Device/templates/designToDeviceBaseHeader.jinja
@@ -21,8 +21,8 @@
 
 {% macro get_parent_struct(class_name) %}
   {% set parent_class_name = designInspector.get_parent(class_name) %}
-  {%- if parent_class_name != None and designInspector.class_has_legit_device_parent(parent_class_name) -%}
-    D{{parent}}
+  {%- if parent_class_name != None and designInspector.class_has_legit_device_parent(class_name) -%}
+    D{{parent_class_name}}
   {%- else -%}
     struct{/*No Device Logic for parent {{parent_class_name}} of {{class_name}}*/}
   {%- endif -%}


### PR DESCRIPTION
Fix for OPCUA-3229

This branch branched from master at 26255066d34c1dc15e3b512f50e782000964aa74 - so, should be a direct fix for what is currently in master branch.

Tested with designs
SCA
CAEN
test design spec'd in [defect description](https://its.cern.ch/jira/browse/OPCUA-3229?focusedId=6588849&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-6588849)