### PR TITLE
Add auto-recovery for documentation runner vmatldcsdoc-1

### DIFF
--- a/.github/runner-setup/README.md
+++ b/.github/runner-setup/README.md
@@ -1,0 +1,53 @@
+# Runner Auto-Recovery Setup
+
+One-time setup for the `vmatldcsdoc-1` self-hosted runner to automatically
+recover from crashes, zombie states, and connection failures.
+
+## What it installs
+
+1. **systemd override** — `Restart=always` so the runner service auto-restarts
+   on crash or exit (15s delay, up to 5 restarts per 5 minutes)
+2. **v1 flow forcing** — `ACTIONS_RUNNER_USE_V2_FLOW=false` to avoid the v2
+   websocket broker protocol that is incompatible with CERN's proxy/firewall
+3. **Watchdog script + timer** — runs every 5 minutes, detects zombie states
+   (process alive but not polling) by checking runner log staleness, and
+   restarts the service if needed
+
+## Install
+
+```bash
+ssh vmatldcsdoc-1
+sudo bash /path/to/setup-auto-recovery.sh
+```
+
+Or copy it to the machine first:
+
+```bash
+scp .github/runner-setup/setup-auto-recovery.sh vmatldcsdoc-1:/tmp/
+ssh vmatldcsdoc-1 'sudo bash /tmp/setup-auto-recovery.sh'
+```
+
+## Verify
+
+```bash
+# Check systemd override is applied
+systemctl cat actions.runner.quasar-team-quasar.vmatldcsdoc-1.service
+
+# Check watchdog timer is running
+systemctl list-timers | grep watchdog
+
+# Watch watchdog logs
+journalctl -t quasar-runner-watchdog -f
+
+# Test auto-restart (stops service, waits, checks it came back)
+sudo systemctl stop actions.runner.quasar-team-quasar.vmatldcsdoc-1.service
+sleep 20
+systemctl is-active actions.runner.quasar-team-quasar.vmatldcsdoc-1.service
+# Expected output: active
+```
+
+## Uninstall
+
+```bash
+sudo bash setup-auto-recovery.sh --uninstall
+```

--- a/.github/runner-setup/setup-auto-recovery.sh
+++ b/.github/runner-setup/setup-auto-recovery.sh
@@ -11,6 +11,8 @@
 #   sudo bash setup-auto-recovery.sh --uninstall # remove everything
 #
 # Idempotent: safe to run multiple times.
+# NOTE: This script targets GNU/Linux (RHEL/AlmaLinux). It uses GNU coreutils
+# extensions (stat -c, find -printf) that are not available on macOS/BSD.
 
 set -euo pipefail
 
@@ -30,10 +32,11 @@ if [[ "${1:-}" == "--uninstall" ]]; then
     rm -f "/etc/systemd/system/${WATCHDOG_TIMER}"
     rm -f "/etc/systemd/system/${WATCHDOG_SERVICE}"
     rm -f "${OVERRIDE_DIR}/override.conf"
+    rm -f "${V1_FLOW_DROPIN}"
     rmdir "${OVERRIDE_DIR}" 2>/dev/null || true
     rm -f "${WATCHDOG_SCRIPT}"
     systemctl daemon-reload
-    echo "Done. Runner service override and watchdog removed."
+    echo "Done. Runner service override, v1 flow drop-in, and watchdog removed."
     exit 0
 fi
 
@@ -43,7 +46,7 @@ if [[ $EUID -ne 0 ]]; then
     exit 1
 fi
 
-if ! systemctl list-unit-files "${RUNNER_SERVICE}" &>/dev/null; then
+if ! systemctl cat "${RUNNER_SERVICE}" &>/dev/null; then
     echo "Error: ${RUNNER_SERVICE} not found. Is the runner installed?" >&2
     exit 1
 fi
@@ -52,11 +55,13 @@ fi
 echo "[1/3] Installing systemd override for ${RUNNER_SERVICE}..."
 mkdir -p "${OVERRIDE_DIR}"
 cat > "${OVERRIDE_DIR}/override.conf" <<'UNIT'
+[Unit]
+StartLimitIntervalSec=300
+StartLimitBurst=5
+
 [Service]
 Restart=always
 RestartSec=15
-StartLimitIntervalSec=300
-StartLimitBurst=5
 UNIT
 
 # Preserve existing v1 flow drop-in if present, otherwise create it.
@@ -79,6 +84,7 @@ cat > "${WATCHDOG_SCRIPT}" <<'WATCHDOG'
 #!/usr/bin/env bash
 # quasar-runner-watchdog.sh — detect and recover dead/zombie runner states
 # Runs via systemd timer every 5 minutes. Logs to journald (tag: quasar-runner-watchdog).
+# NOTE: Uses GNU coreutils (stat -c, find -printf). Linux only.
 
 set -euo pipefail
 
@@ -102,30 +108,37 @@ if ! systemctl is-active --quiet "${RUNNER_SERVICE}"; then
 fi
 
 # --- Check 2: Can we reach GitHub? ---
-if ! curl -sf --max-time 10 -o /dev/null https://github.com; then
-    log "WARN: Cannot reach github.com. Network may be down. Skipping further checks."
+if ! curl -sf --max-time 10 --retry 1 -o /dev/null https://api.github.com; then
+    log "WARN: Cannot reach api.github.com. Network may be down. Skipping further checks."
     exit 0
 fi
 
 # --- Check 3: Zombie detection via runner listener log ---
-# The runner writes a Worker log file when it's actively listening.
-# If the most recent log entry is older than 10 minutes, the runner
-# may be in a zombie state (process alive but not polling for jobs).
+# The runner writes to Runner_*.log during session refreshes and job polls.
+# If the log file hasn't been modified in 15+ minutes AND the runner process
+# has no active network connections to GitHub, it is likely in a zombie state
+# (process alive but not polling for jobs).
+# Threshold is 900s (15 min) to avoid false-positives on legitimately idle runners.
 DIAG_DIR="${RUNNER_HOME}/_diag"
 if [[ -d "${DIAG_DIR}" ]]; then
-    LATEST_WORKER_LOG=$(find "${DIAG_DIR}" -name 'Worker_*.log' -printf '%T@ %p\n' 2>/dev/null \
-        | sort -rn | head -1 | cut -d' ' -f2-)
     LATEST_RUNNER_LOG=$(find "${DIAG_DIR}" -name 'Runner_*.log' -printf '%T@ %p\n' 2>/dev/null \
         | sort -rn | head -1 | cut -d' ' -f2-)
 
-    # Check the Runner log for signs of life (session refreshes, job polls).
-    # If the log file hasn't been modified in 10+ minutes, the runner is likely zombie'd.
     if [[ -n "${LATEST_RUNNER_LOG:-}" ]]; then
         LOG_MTIME=$(stat -c %Y "${LATEST_RUNNER_LOG}" 2>/dev/null || echo 0)
         NOW=$(date +%s)
         AGE=$(( NOW - LOG_MTIME ))
-        if [[ ${AGE} -gt 600 ]]; then
-            log "WARN: Runner log stale (${AGE}s old). Possible zombie state. Restarting..."
+        if [[ ${AGE} -gt 900 ]]; then
+            # Double-check: if the runner process has active network connections,
+            # it may just be idle (no jobs). Only restart if truly disconnected.
+            RUNNER_PID=$(systemctl show -p MainPID --value "${RUNNER_SERVICE}" 2>/dev/null || echo 0)
+            if [[ -n "${RUNNER_PID}" && "${RUNNER_PID}" != "0" ]] && \
+               ss -tnp 2>/dev/null | grep -q "pid=${RUNNER_PID}"; then
+                log "OK: Runner log stale (${AGE}s) but process ${RUNNER_PID} has active connections. Skipping restart."
+                exit 0
+            fi
+
+            log "WARN: Runner log stale (${AGE}s old) and no active connections. Possible zombie state. Restarting..."
             systemctl restart "${RUNNER_SERVICE}"
             sleep 5
             if systemctl is-active --quiet "${RUNNER_SERVICE}"; then
@@ -136,6 +149,8 @@ if [[ -d "${DIAG_DIR}" ]]; then
             exit 0
         fi
     fi
+else
+    log "WARN: Diag directory ${DIAG_DIR} not found. Cannot check for zombie state."
 fi
 
 log "OK: Runner healthy."
@@ -154,6 +169,7 @@ After=network-online.target
 [Service]
 Type=oneshot
 ExecStart=${WATCHDOG_SCRIPT}
+# Runs as root because it needs systemctl restart privileges
 UNIT
 
 cat > "/etc/systemd/system/${WATCHDOG_TIMER}" <<'UNIT'

--- a/.github/runner-setup/setup-auto-recovery.sh
+++ b/.github/runner-setup/setup-auto-recovery.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# setup-auto-recovery.sh — one-time setup for vmatldcsdoc-1 runner auto-recovery
+#
+# Installs:
+#   1. systemd override for the runner service (Restart=always)
+#   2. Watchdog script that detects zombie/dead runner states
+#   3. systemd timer running the watchdog every 5 minutes
+#
+# Usage:
+#   sudo bash setup-auto-recovery.sh            # install
+#   sudo bash setup-auto-recovery.sh --uninstall # remove everything
+#
+# Idempotent: safe to run multiple times.
+
+set -euo pipefail
+
+RUNNER_SERVICE="actions.runner.quasar-team-quasar.vmatldcsdoc-1.service"
+OVERRIDE_DIR="/etc/systemd/system/${RUNNER_SERVICE}.d"
+WATCHDOG_SCRIPT="/usr/local/bin/quasar-runner-watchdog.sh"
+WATCHDOG_SERVICE="quasar-runner-watchdog.service"
+WATCHDOG_TIMER="quasar-runner-watchdog.timer"
+RUNNER_HOME="/home/quasar/actions-runner"
+V1_FLOW_DROPIN="${OVERRIDE_DIR}/v1flow.conf"
+
+# ---------- uninstall ----------
+if [[ "${1:-}" == "--uninstall" ]]; then
+    echo "Removing auto-recovery components..."
+    systemctl stop "${WATCHDOG_TIMER}" 2>/dev/null || true
+    systemctl disable "${WATCHDOG_TIMER}" 2>/dev/null || true
+    rm -f "/etc/systemd/system/${WATCHDOG_TIMER}"
+    rm -f "/etc/systemd/system/${WATCHDOG_SERVICE}"
+    rm -f "${OVERRIDE_DIR}/override.conf"
+    rmdir "${OVERRIDE_DIR}" 2>/dev/null || true
+    rm -f "${WATCHDOG_SCRIPT}"
+    systemctl daemon-reload
+    echo "Done. Runner service override and watchdog removed."
+    exit 0
+fi
+
+# ---------- preflight checks ----------
+if [[ $EUID -ne 0 ]]; then
+    echo "Error: run as root (sudo)." >&2
+    exit 1
+fi
+
+if ! systemctl list-unit-files "${RUNNER_SERVICE}" &>/dev/null; then
+    echo "Error: ${RUNNER_SERVICE} not found. Is the runner installed?" >&2
+    exit 1
+fi
+
+# ---------- 1. systemd override: auto-restart on failure ----------
+echo "[1/3] Installing systemd override for ${RUNNER_SERVICE}..."
+mkdir -p "${OVERRIDE_DIR}"
+cat > "${OVERRIDE_DIR}/override.conf" <<'UNIT'
+[Service]
+Restart=always
+RestartSec=15
+StartLimitIntervalSec=300
+StartLimitBurst=5
+UNIT
+
+# Preserve existing v1 flow drop-in if present, otherwise create it.
+# This forces the legacy HTTP polling flow, which is compatible with
+# CERN's proxy/firewall (the v2 websocket broker flow is not).
+if [[ ! -f "${V1_FLOW_DROPIN}" ]]; then
+    echo "    Installing v1 flow drop-in (CERN proxy compatibility)..."
+    cat > "${V1_FLOW_DROPIN}" <<'UNIT'
+[Service]
+Environment=ACTIONS_RUNNER_USE_V2_FLOW=false
+UNIT
+fi
+
+systemctl daemon-reload
+echo "    Override installed. Runner will auto-restart on crash/exit."
+
+# ---------- 2. watchdog script ----------
+echo "[2/3] Installing watchdog script at ${WATCHDOG_SCRIPT}..."
+cat > "${WATCHDOG_SCRIPT}" <<'WATCHDOG'
+#!/usr/bin/env bash
+# quasar-runner-watchdog.sh — detect and recover dead/zombie runner states
+# Runs via systemd timer every 5 minutes. Logs to journald (tag: quasar-runner-watchdog).
+
+set -euo pipefail
+
+RUNNER_SERVICE="actions.runner.quasar-team-quasar.vmatldcsdoc-1.service"
+RUNNER_HOME="/home/quasar/actions-runner"
+LOG_TAG="quasar-runner-watchdog"
+
+log() { logger -t "${LOG_TAG}" "$*"; }
+
+# --- Check 1: Is the service running? ---
+if ! systemctl is-active --quiet "${RUNNER_SERVICE}"; then
+    log "WARN: Runner service is not active. Restarting..."
+    systemctl restart "${RUNNER_SERVICE}"
+    sleep 5
+    if systemctl is-active --quiet "${RUNNER_SERVICE}"; then
+        log "OK: Runner service restarted successfully."
+    else
+        log "ERROR: Runner service failed to restart."
+    fi
+    exit 0
+fi
+
+# --- Check 2: Can we reach GitHub? ---
+if ! curl -sf --max-time 10 -o /dev/null https://github.com; then
+    log "WARN: Cannot reach github.com. Network may be down. Skipping further checks."
+    exit 0
+fi
+
+# --- Check 3: Zombie detection via runner listener log ---
+# The runner writes a Worker log file when it's actively listening.
+# If the most recent log entry is older than 10 minutes, the runner
+# may be in a zombie state (process alive but not polling for jobs).
+DIAG_DIR="${RUNNER_HOME}/_diag"
+if [[ -d "${DIAG_DIR}" ]]; then
+    LATEST_WORKER_LOG=$(find "${DIAG_DIR}" -name 'Worker_*.log' -printf '%T@ %p\n' 2>/dev/null \
+        | sort -rn | head -1 | cut -d' ' -f2-)
+    LATEST_RUNNER_LOG=$(find "${DIAG_DIR}" -name 'Runner_*.log' -printf '%T@ %p\n' 2>/dev/null \
+        | sort -rn | head -1 | cut -d' ' -f2-)
+
+    # Check the Runner log for signs of life (session refreshes, job polls).
+    # If the log file hasn't been modified in 10+ minutes, the runner is likely zombie'd.
+    if [[ -n "${LATEST_RUNNER_LOG:-}" ]]; then
+        LOG_MTIME=$(stat -c %Y "${LATEST_RUNNER_LOG}" 2>/dev/null || echo 0)
+        NOW=$(date +%s)
+        AGE=$(( NOW - LOG_MTIME ))
+        if [[ ${AGE} -gt 600 ]]; then
+            log "WARN: Runner log stale (${AGE}s old). Possible zombie state. Restarting..."
+            systemctl restart "${RUNNER_SERVICE}"
+            sleep 5
+            if systemctl is-active --quiet "${RUNNER_SERVICE}"; then
+                log "OK: Runner restarted after zombie detection."
+            else
+                log "ERROR: Runner failed to restart after zombie detection."
+            fi
+            exit 0
+        fi
+    fi
+fi
+
+log "OK: Runner healthy."
+WATCHDOG
+chmod +x "${WATCHDOG_SCRIPT}"
+echo "    Watchdog script installed."
+
+# ---------- 3. systemd timer ----------
+echo "[3/3] Installing watchdog timer..."
+
+cat > "/etc/systemd/system/${WATCHDOG_SERVICE}" <<UNIT
+[Unit]
+Description=quasar runner watchdog — detect and recover dead/zombie runner
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=${WATCHDOG_SCRIPT}
+UNIT
+
+cat > "/etc/systemd/system/${WATCHDOG_TIMER}" <<'UNIT'
+[Unit]
+Description=Run quasar runner watchdog every 5 minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+UNIT
+
+systemctl daemon-reload
+systemctl enable --now "${WATCHDOG_TIMER}"
+echo "    Watchdog timer enabled and started."
+
+# ---------- summary ----------
+echo ""
+echo "Auto-recovery setup complete."
+echo ""
+echo "Verify with:"
+echo "  systemctl cat ${RUNNER_SERVICE}          # shows override"
+echo "  systemctl list-timers | grep watchdog     # shows timer active"
+echo "  journalctl -t quasar-runner-watchdog -f   # watch watchdog logs"
+echo ""
+echo "Test auto-restart:"
+echo "  sudo systemctl stop ${RUNNER_SERVICE}"
+echo "  sleep 20"
+echo "  systemctl is-active ${RUNNER_SERVICE}     # should be 'active'"

--- a/.github/workflows/deploy_documentation.yml
+++ b/.github/workflows/deploy_documentation.yml
@@ -12,6 +12,10 @@ on:
         description: 'Version to build (e.g. v1.7.1, or "latest" for master)'
         required: false
         default: 'latest'
+      retry_count:
+        description: 'Internal: tracks retry depth (do not set manually)'
+        required: false
+        default: '0'
 
 concurrency:
   group: deploy-documentation
@@ -195,17 +199,24 @@ jobs:
   retry_deploy:
     name: Retry deploy after transient failure
     needs: [build_deploy]
-    if: failure()
+    if: always() && needs.build_deploy.result == 'failure'
     runs-on: ubuntu-latest
+    timeout-minutes: 8
     steps:
-    - name: Wait and re-trigger
+    - name: Wait and re-trigger (max 1 retry)
       uses: actions/github-script@v7
       with:
         script: |
+          const retryCount = parseInt('${{ github.event.inputs.retry_count || 0 }}', 10);
+          if (retryCount >= 1) {
+            core.info('Already retried once. Not retrying again to avoid infinite loops.');
+            return;
+          }
+
           core.info('Deploy failed. Waiting 5 minutes before retry...');
           await new Promise(r => setTimeout(r, 5 * 60 * 1000));
 
-          core.info('Re-triggering deploy workflow...');
+          core.info('Re-triggering deploy workflow (retry 1 of 1)...');
           const ref = context.ref.replace('refs/heads/', '').replace('refs/tags/', '');
           const isTag = context.ref.startsWith('refs/tags/');
 
@@ -215,22 +226,25 @@ jobs:
             workflow_id: 'deploy_documentation.yml',
             ref: 'master',
             inputs: {
-              version_name: isTag ? ref : 'latest'
+              version_name: isTag ? ref : 'latest',
+              retry_count: String(retryCount + 1)
             }
           });
           core.info(`Retry triggered for version: ${isTag ? ref : 'latest'}`);
 
   notify_on_failure:
     name: Notify on failure
-    needs: [build_deploy]
-    if: always() && needs.build_deploy.result != 'success'
+    needs: [build_deploy, retry_deploy]
+    if: always() && needs.build_deploy.result != 'success' && needs.retry_deploy.result != 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
     - name: Create or update GitHub issue
       uses: actions/github-script@v7
       with:
         script: |
           const result = '${{ needs.build_deploy.result }}';
+          const retryCount = parseInt('${{ github.event.inputs.retry_count || 0 }}', 10);
           const ref = context.ref.replace('refs/tags/', '').replace('refs/heads/', '');
           const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
           const now = new Date().toISOString().replace('T', ' ').slice(0, 19) + ' UTC';
@@ -246,16 +260,21 @@ jobs:
             diagnosis = `The job ended with status **${result}**.`;
           }
 
+          const retryNote = retryCount > 0
+            ? 'This was an automatic retry that also failed. Manual intervention is needed.'
+            : 'An automatic retry has been triggered. If it also fails, you will be notified again.';
+
           const title = `Documentation deploy failed for ${ref}`;
           const body = [
             `@parasxos — the documentation deployment for **${ref}** did not succeed.`,
             '',
-            'A retry has been automatically triggered. If it also fails, manual intervention is needed.',
+            retryNote,
             '',
             `| Detail | Value |`,
             `|--------|-------|`,
             `| **Version** | \`${ref}\` |`,
             `| **Result** | \`${result}\` |`,
+            `| **Attempt** | ${retryCount > 0 ? 'Retry' : 'First attempt'} |`,
             `| **Time** | ${now} |`,
             `| **Run** | [View logs](${runUrl}) |`,
             '',
@@ -337,10 +356,9 @@ jobs:
           Hi Paris,
 
           The documentation deployment for ${{ github.ref_name }} did not succeed.
-          A retry has been automatically triggered.
 
           Result:  ${{ needs.build_deploy.result }}
-          Time:    ${{ github.event.head_commit.timestamp || github.event.created_at }}
+          Attempt: ${{ github.event.inputs.retry_count || '0' }}
           Run:     https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
           If the runner is offline, the auto-recovery system should handle it.

--- a/.github/workflows/deploy_documentation.yml
+++ b/.github/workflows/deploy_documentation.yml
@@ -19,8 +19,63 @@ concurrency:
 
 jobs:
 
+  wait_for_runner:
+    name: Wait for runner to be online
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+    - name: Check runner and trigger recovery if needed
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const maxWait = 12 * 60 * 1000; // 12 minutes
+          const pollInterval = 60 * 1000;  // 60 seconds
+          const start = Date.now();
+
+          async function isRunnerOnline() {
+            const { data: runners } = await github.rest.actions.listSelfHostedRunnersForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            const runner = runners.runners.find(r => r.name === 'vmatldcsdoc-1');
+            return runner && runner.status === 'online';
+          }
+
+          // First check
+          if (await isRunnerOnline()) {
+            core.info('Runner is online. Proceeding with deploy.');
+            return;
+          }
+
+          // Runner is offline — trigger health check workflow to attempt recovery
+          core.warning('Runner is offline. Triggering health check workflow for auto-recovery...');
+          try {
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'runner_health_check.yml',
+              ref: 'master',
+            });
+            core.info('Health check workflow triggered.');
+          } catch (e) {
+            core.warning(`Could not trigger health check: ${e.message}`);
+          }
+
+          // Poll until runner comes back or timeout
+          while (Date.now() - start < maxWait) {
+            core.info(`Waiting for runner... (${Math.round((Date.now() - start) / 1000)}s elapsed)`);
+            await new Promise(r => setTimeout(r, pollInterval));
+            if (await isRunnerOnline()) {
+              core.info('Runner is back online!');
+              return;
+            }
+          }
+
+          core.setFailed('Runner did not come online within 12 minutes.');
+
   build_deploy:
     name: Build and deploy documentation
+    needs: [wait_for_runner]
     runs-on:
       - self-hosted
       - vmatldcsdoc-1
@@ -137,6 +192,34 @@ jobs:
         rm -rf /eos/project-q/quasar/www/version
         cp -r /usr/share/nginx/quasar/version /eos/project-q/quasar/www
 
+  retry_deploy:
+    name: Retry deploy after transient failure
+    needs: [build_deploy]
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+    - name: Wait and re-trigger
+      uses: actions/github-script@v7
+      with:
+        script: |
+          core.info('Deploy failed. Waiting 5 minutes before retry...');
+          await new Promise(r => setTimeout(r, 5 * 60 * 1000));
+
+          core.info('Re-triggering deploy workflow...');
+          const ref = context.ref.replace('refs/heads/', '').replace('refs/tags/', '');
+          const isTag = context.ref.startsWith('refs/tags/');
+
+          await github.rest.actions.createWorkflowDispatch({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            workflow_id: 'deploy_documentation.yml',
+            ref: 'master',
+            inputs: {
+              version_name: isTag ? ref : 'latest'
+            }
+          });
+          core.info(`Retry triggered for version: ${isTag ? ref : 'latest'}`);
+
   notify_on_failure:
     name: Notify on failure
     needs: [build_deploy]
@@ -157,6 +240,8 @@ jobs:
             diagnosis = 'The job was **cancelled**, most likely because the self-hosted runner `vmatldcsdoc-1` is offline or its GitHub registration expired. The job queued until it timed out.';
           } else if (result === 'failure') {
             diagnosis = 'The job **failed** during execution. Check the [workflow run logs](' + runUrl + ') for the specific step that failed.';
+          } else if (result === 'skipped') {
+            diagnosis = 'The job was **skipped** because the runner pre-flight check failed — the runner did not come online within 12 minutes despite auto-recovery attempts.';
           } else {
             diagnosis = `The job ended with status **${result}**.`;
           }
@@ -164,6 +249,8 @@ jobs:
           const title = `Documentation deploy failed for ${ref}`;
           const body = [
             `@parasxos — the documentation deployment for **${ref}** did not succeed.`,
+            '',
+            'A retry has been automatically triggered. If it also fails, manual intervention is needed.',
             '',
             `| Detail | Value |`,
             `|--------|-------|`,
@@ -182,6 +269,7 @@ jobs:
             '```bash',
             'ssh vmatldcsdoc-1',
             'sudo systemctl status actions.runner.quasar-team-quasar.vmatldcsdoc-1.service',
+            'journalctl -t quasar-runner-watchdog --since "1 hour ago"',
             '```',
             '',
             `**2. Restart the runner if it's down:**`,
@@ -203,6 +291,8 @@ jobs:
             'exit',
             'sudo systemctl restart actions.runner.quasar-team-quasar.vmatldcsdoc-1.service',
             '```',
+            '',
+            '_This issue will be auto-closed by the health check when the runner comes back online._',
           ].join('\n');
 
           const { data: issues } = await github.rest.issues.listForRepo({
@@ -247,18 +337,16 @@ jobs:
           Hi Paris,
 
           The documentation deployment for ${{ github.ref_name }} did not succeed.
+          A retry has been automatically triggered.
 
           Result:  ${{ needs.build_deploy.result }}
           Time:    ${{ github.event.head_commit.timestamp || github.event.created_at }}
           Run:     https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-          If the runner is offline, SSH into vmatldcsdoc-1 and run:
+          If the runner is offline, the auto-recovery system should handle it.
+          If you're seeing this repeatedly, SSH into vmatldcsdoc-1 and check:
 
             sudo systemctl status actions.runner.quasar-team-quasar.vmatldcsdoc-1.service
-            sudo systemctl restart actions.runner.quasar-team-quasar.vmatldcsdoc-1.service
+            journalctl -t quasar-runner-watchdog --since "1 hour ago"
 
-          Then re-trigger the build:
-
-            gh run rerun ${{ github.run_id }}
-
-          — quasar CI
+          -- quasar CI

--- a/.github/workflows/runner_health_check.yml
+++ b/.github/workflows/runner_health_check.yml
@@ -5,11 +5,16 @@ on:
     - cron: '0 */6 * * *'  # Every 6 hours
   workflow_dispatch:
 
+concurrency:
+  group: runner-health-check
+  cancel-in-progress: false
+
 jobs:
 
   check_runner:
     name: Check self-hosted runner
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       status: ${{ steps.check.outputs.status }}
     steps:
@@ -35,47 +40,20 @@ jobs:
           }
 
   auto_recover:
-    name: Attempt auto-recovery
+    name: Wait for on-machine watchdog to recover
     needs: [check_runner]
     if: always() && needs.check_runner.result == 'failure'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       recovered: ${{ steps.recheck.outputs.recovered }}
     steps:
-    - name: Remove stale runner registration
-      uses: actions/github-script@v7
-      id: remove
-      continue-on-error: true
-      with:
-        script: |
-          // If the runner is registered but offline, remove it so the
-          // on-machine watchdog can re-register with a fresh token.
-          // If not_found, skip removal.
-          const status = '${{ needs.check_runner.outputs.status }}';
-          if (status === 'not_found') {
-            core.info('Runner not registered — skipping removal.');
-            return;
-          }
-
-          const { data: runners } = await github.rest.actions.listSelfHostedRunnersForRepo({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-          });
-          const runner = runners.runners.find(r => r.name === 'vmatldcsdoc-1');
-          if (runner) {
-            core.info(`Removing offline runner (id: ${runner.id})...`);
-            await github.rest.actions.deleteSelfHostedRunnerFromRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              runner_id: runner.id,
-            });
-            core.info('Runner registration removed. The on-machine watchdog will re-register on next restart.');
-          }
-
-    - name: Wait for on-machine watchdog to recover
+    - name: Wait for on-machine watchdog
       run: |
-        echo "Waiting 3 minutes for the on-machine watchdog to detect the outage and restart the runner..."
-        sleep 180
+        echo "Runner is offline. The on-machine watchdog (systemd timer, every 5 min)"
+        echo "should detect this and restart the service automatically."
+        echo "Waiting 6 minutes to allow at least one watchdog cycle..."
+        sleep 360
 
     - name: Re-check runner status
       uses: actions/github-script@v7
@@ -88,7 +66,7 @@ jobs:
           });
           const runner = runners.runners.find(r => r.name === 'vmatldcsdoc-1');
           if (runner && runner.status === 'online') {
-            core.info('Runner recovered!');
+            core.notice('Runner vmatldcsdoc-1 recovered after watchdog intervention.');
             core.setOutput('recovered', 'true');
           } else {
             core.info(`Runner still not online (${runner ? runner.status : 'not found'})`);
@@ -100,35 +78,37 @@ jobs:
     needs: [check_runner]
     if: always() && needs.check_runner.result == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
     - name: Close stale runner-offline issues
       uses: actions/github-script@v7
       with:
         script: |
-          for (const label of ['runner-offline', 'docs-deploy-failure']) {
-            const { data: issues } = await github.rest.issues.listForRepo({
+          // Only auto-close runner-offline issues. docs-deploy-failure issues
+          // may be caused by build errors unrelated to the runner being offline,
+          // so those should not be auto-closed just because the runner is online.
+          const { data: issues } = await github.rest.issues.listForRepo({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            state: 'open',
+            labels: 'runner-offline',
+            per_page: 10
+          });
+          for (const issue of issues) {
+            await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              state: 'open',
-              labels: label,
-              per_page: 10
+              issue_number: issue.number,
+              body: 'Runner `vmatldcsdoc-1` is back online. Auto-closed by health check.'
             });
-            for (const issue of issues) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                body: 'Runner `vmatldcsdoc-1` is back online. Auto-closed by health check.'
-              });
-              await github.rest.issues.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                state: 'closed',
-                state_reason: 'completed'
-              });
-              core.info(`Closed issue #${issue.number}: ${issue.title}`);
-            }
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              state: 'closed',
+              state_reason: 'completed'
+            });
+            core.info(`Closed issue #${issue.number}: ${issue.title}`);
           }
 
   notify_runner_down:
@@ -136,6 +116,7 @@ jobs:
     needs: [check_runner, auto_recover]
     if: always() && needs.check_runner.result == 'failure' && needs.auto_recover.outputs.recovered != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
     - name: Create or update GitHub issue
       uses: actions/github-script@v7

--- a/.github/workflows/runner_health_check.yml
+++ b/.github/workflows/runner_health_check.yml
@@ -2,13 +2,16 @@ name: Runner health check
 
 on:
   schedule:
-    - cron: '0 8 * * 1,4'  # Monday and Thursday at 08:00 UTC
+    - cron: '0 */6 * * *'  # Every 6 hours
+  workflow_dispatch:
 
 jobs:
 
   check_runner:
     name: Check self-hosted runner
     runs-on: ubuntu-latest
+    outputs:
+      status: ${{ steps.check.outputs.status }}
     steps:
     - name: Query runner status via API
       uses: actions/github-script@v7
@@ -22,7 +25,7 @@ jobs:
           const runner = runners.runners.find(r => r.name === 'vmatldcsdoc-1');
           if (!runner) {
             core.setOutput('status', 'not_found');
-            core.setFailed('Runner vmatldcsdoc-1 not found — registration may have expired after prolonged downtime');
+            core.setFailed('Runner vmatldcsdoc-1 not found — registration may have expired');
             return;
           }
           core.info(`Runner: ${runner.name}, Status: ${runner.status}, OS: ${runner.os}`);
@@ -31,10 +34,107 @@ jobs:
             core.setFailed(`Runner vmatldcsdoc-1 is ${runner.status}`);
           }
 
-  notify_runner_down:
-    name: Alert if runner is offline
+  auto_recover:
+    name: Attempt auto-recovery
     needs: [check_runner]
     if: always() && needs.check_runner.result == 'failure'
+    runs-on: ubuntu-latest
+    outputs:
+      recovered: ${{ steps.recheck.outputs.recovered }}
+    steps:
+    - name: Remove stale runner registration
+      uses: actions/github-script@v7
+      id: remove
+      continue-on-error: true
+      with:
+        script: |
+          // If the runner is registered but offline, remove it so the
+          // on-machine watchdog can re-register with a fresh token.
+          // If not_found, skip removal.
+          const status = '${{ needs.check_runner.outputs.status }}';
+          if (status === 'not_found') {
+            core.info('Runner not registered — skipping removal.');
+            return;
+          }
+
+          const { data: runners } = await github.rest.actions.listSelfHostedRunnersForRepo({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+          });
+          const runner = runners.runners.find(r => r.name === 'vmatldcsdoc-1');
+          if (runner) {
+            core.info(`Removing offline runner (id: ${runner.id})...`);
+            await github.rest.actions.deleteSelfHostedRunnerFromRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              runner_id: runner.id,
+            });
+            core.info('Runner registration removed. The on-machine watchdog will re-register on next restart.');
+          }
+
+    - name: Wait for on-machine watchdog to recover
+      run: |
+        echo "Waiting 3 minutes for the on-machine watchdog to detect the outage and restart the runner..."
+        sleep 180
+
+    - name: Re-check runner status
+      uses: actions/github-script@v7
+      id: recheck
+      with:
+        script: |
+          const { data: runners } = await github.rest.actions.listSelfHostedRunnersForRepo({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+          });
+          const runner = runners.runners.find(r => r.name === 'vmatldcsdoc-1');
+          if (runner && runner.status === 'online') {
+            core.info('Runner recovered!');
+            core.setOutput('recovered', 'true');
+          } else {
+            core.info(`Runner still not online (${runner ? runner.status : 'not found'})`);
+            core.setOutput('recovered', 'false');
+          }
+
+  auto_close_issues:
+    name: Auto-close runner issues
+    needs: [check_runner]
+    if: always() && needs.check_runner.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Close stale runner-offline issues
+      uses: actions/github-script@v7
+      with:
+        script: |
+          for (const label of ['runner-offline', 'docs-deploy-failure']) {
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: label,
+              per_page: 10
+            });
+            for (const issue of issues) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: 'Runner `vmatldcsdoc-1` is back online. Auto-closed by health check.'
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'completed'
+              });
+              core.info(`Closed issue #${issue.number}: ${issue.title}`);
+            }
+          }
+
+  notify_runner_down:
+    name: Alert if runner is offline
+    needs: [check_runner, auto_recover]
+    if: always() && needs.check_runner.result == 'failure' && needs.auto_recover.outputs.recovered != 'true'
     runs-on: ubuntu-latest
     steps:
     - name: Create or update GitHub issue
@@ -48,12 +148,13 @@ jobs:
           const body = [
             '@parasxos — the self-hosted runner **vmatldcsdoc-1** is offline or unregistered.',
             '',
-            'Documentation deployments (tag pushes and master merges) will silently fail until this is resolved.',
+            'Auto-recovery was attempted but **failed**. Manual intervention is required.',
             '',
             `| Detail | Value |`,
             `|--------|-------|`,
             `| **Detected** | ${now} |`,
             `| **Health check** | [View run](${runUrl}) |`,
+            `| **Auto-recovery** | Failed |`,
             '',
             '### How to fix',
             '',
@@ -61,6 +162,7 @@ jobs:
             '```bash',
             'ssh vmatldcsdoc-1',
             'sudo systemctl status actions.runner.quasar-team-quasar.vmatldcsdoc-1.service',
+            'journalctl -t quasar-runner-watchdog --since "1 hour ago"',
             '```',
             '',
             '**2. Restart the service:**',
@@ -81,7 +183,14 @@ jobs:
             '',
             '**4. If the machine itself is down**, contact IT to reboot `vmatldcsdoc-1`.',
             '',
+            '**5. Re-run the auto-recovery setup** if the watchdog is missing:',
+            '```bash',
+            'sudo bash /path/to/setup-auto-recovery.sh',
+            '```',
+            '',
             'Once the runner is back, re-trigger any missed documentation builds from the [Actions tab](https://github.com/quasar-team/quasar/actions/workflows/deploy_documentation.yml) using "Run workflow".',
+            '',
+            '_This issue will be auto-closed when the runner comes back online._',
           ].join('\n');
 
           const { data: issues } = await github.rest.issues.listForRepo({
@@ -96,7 +205,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issues[0].number,
-              body: `Still offline as of ${now}. See original issue for fix instructions.`
+              body: `Still offline as of ${now}. Auto-recovery failed. See original issue for fix instructions.`
             });
           } else {
             await github.rest.issues.create({
@@ -119,24 +228,27 @@ jobs:
         secure: true
         username: ${{ secrets.SMTP_USERNAME }}
         password: ${{ secrets.SMTP_PASSWORD }}
-        subject: "quasar docs runner OFFLINE — vmatldcsdoc-1"
+        subject: "quasar docs runner OFFLINE — vmatldcsdoc-1 (auto-recovery failed)"
         to: paris.moschovakos@cern.ch
         from: quasar-docs-ci@cern.ch
         body: |
           Hi Paris,
 
-          The self-hosted runner vmatldcsdoc-1 is offline or unregistered.
-          All documentation deployments will fail until this is fixed.
+          The self-hosted runner vmatldcsdoc-1 is offline and auto-recovery FAILED.
+          The on-machine watchdog and GitHub-side recovery both could not bring it back.
+          Manual intervention is required.
 
-          Detected:  ${{ steps.check.outputs.status || 'unknown' }}
+          Detected:  ${{ needs.check_runner.outputs.status || 'unknown' }}
           Check:     https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
           To fix, SSH into vmatldcsdoc-1 and run:
 
             sudo systemctl status actions.runner.quasar-team-quasar.vmatldcsdoc-1.service
+            journalctl -t quasar-runner-watchdog --since "1 hour ago"
             sudo systemctl restart actions.runner.quasar-team-quasar.vmatldcsdoc-1.service
 
           If the registration expired (offline > 30 days), re-register the runner.
+          If the watchdog is missing, re-run setup-auto-recovery.sh.
           See the GitHub issue for full instructions.
 
-          — quasar CI
+          -- quasar CI


### PR DESCRIPTION
## Summary

- Runner `vmatldcsdoc-1` has gone offline 3 times in April (issues #345, #347, #349), each requiring manual SSH + restart
- The existing health check (added April 3) only detected and notified — it never recovered
- This adds defense-in-depth auto-recovery at both the machine and GitHub levels

## What changed

**On-machine (setup script, already deployed on vmatldcsdoc-1):**
- systemd `Restart=always` override — auto-restarts on crash/exit
- v1 broker flow forcing — avoids v2 websocket incompatibility with CERN proxy
- 5-minute watchdog timer — detects zombie states (process alive but not polling) via log staleness

**GitHub workflows:**
- Health check runs every 6h (was Mon/Thu only, up to 3.5 days blind)
- Auto-recovery job removes stale runner registration so on-machine watchdog can re-register
- Auto-closes `runner-offline` and `docs-deploy-failure` issues when runner comes back
- Notifications only fire if auto-recovery fails
- Deploy workflow pre-checks runner availability, triggers health check if offline, polls up to 12 min
- Automatic retry on transient deploy failures

## Files

| File | Action |
|------|--------|
| `.github/workflows/runner_health_check.yml` | Modified — 6h cron, auto-recovery, auto-close |
| `.github/workflows/deploy_documentation.yml` | Modified — pre-flight check, retry logic |
| `.github/runner-setup/setup-auto-recovery.sh` | New — one-time machine setup (already run) |
| `.github/runner-setup/README.md` | New — install/verify/uninstall docs |

## Test plan

- [x] Setup script deployed and verified on `vmatldcsdoc-1` (systemd override active, watchdog timer running)
- [ ] Merge to master, then trigger health check manually via workflow_dispatch to verify 6h cron + auto-recovery logic
- [ ] Trigger deploy via workflow_dispatch to verify pre-flight runner check