### PR TITLE
OPCUA-3365: Lower CMake minimum from 3.26 to 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,8 @@
 # Author: Stefan Schlenker
 # Author: Paris Moschovakos <paris.moschovakos@cern.ch>
 
-cmake_minimum_required(VERSION 3.26)
+# Floor = the lowest CMake the source actually needs; newer platform CMakes are covered by CI, not pinned here.
+cmake_minimum_required(VERSION 3.16)
 project(opc_ua)
 # the line below is added to quasar to keep backwards compatibility for the transition period.
 cmake_policy(SET CMP0065 NEW)

--- a/Documentation/source/ChangeLog.rst
+++ b/Documentation/source/ChangeLog.rst
@@ -19,7 +19,7 @@ ChangeLog
                 <td valign="top">2.0.0<font size="-1"><br>(TBD)</font><br></td>
                 <!-- Changes introduced -->
                 <td valign="top"><br>
-                    kdiff3 is fully eliminated as a dependency. D&lt;Class&gt; files are now user-owned and never overwritten; Base_D&lt;Class&gt; provides virtual defaults for new design elements. Common/CMakeLists.txt, Server/CMakeLists.txt, main.cpp and Doxyfile are now framework-owned. New <code>CommonCustom.cmake</code> and <code>ServerCustom.cmake</code> provide hooks for project-specific sources (same pattern as <code>DeviceCustom.cmake</code>). A new <code>device_report</code> command shows override status. CMake minimum is bumped to 3.26 for Windows/Linux build parity. ThreadPool data races found by TSan are fixed. The documentation deployment runner gains auto-recovery and a fine-grained API token for runner-status checks.
+                    kdiff3 is fully eliminated as a dependency. D&lt;Class&gt; files are now user-owned and never overwritten; Base_D&lt;Class&gt; provides virtual defaults for new design elements. Common/CMakeLists.txt, Server/CMakeLists.txt, main.cpp and Doxyfile are now framework-owned. New <code>CommonCustom.cmake</code> and <code>ServerCustom.cmake</code> provide hooks for project-specific sources (same pattern as <code>DeviceCustom.cmake</code>). A new <code>device_report</code> command shows override status. CMake minimum is raised to 3.16 (the lowest version the build actually requires). ThreadPool data races found by TSan are fixed. The documentation deployment runner gains auto-recovery and a fine-grained API token for runner-status checks.
                 </td>
                 <!-- Possible backward incompatibilities -->
                 <td valign="top"><br>
@@ -30,7 +30,7 @@ ChangeLog
                         <li>Server/src/main.cpp is now overwritten. Use <code>appendCustomCommandLineOptions()</code>, <code>initialize()</code> or <code>shutdown()</code> hooks in QuasarServer instead.</li>
                         <li>Documentation/Doxyfile is now overwritten on upgrade.</li>
                         <li><code>transformDesign(requiresMerge=...)</code> continues to work via backward-compatibility alias.</li>
-                        <li>CMake minimum is now 3.26 (raised from 3.10).</li>
+                        <li>CMake minimum is now 3.16 (raised from 3.10).</li>
                     </ul>
                 </td>
                 <!-- JIRA Release notes -->
@@ -46,7 +46,8 @@ ChangeLog
                         <li><code>override</code> keyword on D&lt;Class&gt; declarations for compile-time safety</li>
                         <li><code>upgrade_project</code> adds <code>override</code> to existing D&lt;Class&gt; headers automatically</li>
                         <li>Common/CMakeLists.txt, Server/CMakeLists.txt, main.cpp, Doxyfile now framework-owned</li>
-                        <li>[<a href='https://its.cern.ch/jira/browse/OPCUA-3326'>OPCUA-3326</a>] - Modernize CMake to 3.26 minimum for Windows/Linux build parity</li>
+                        <li>[<a href='https://its.cern.ch/jira/browse/OPCUA-3326'>OPCUA-3326</a>] - Modernize CMake build (Boost CONFIG mode, Windows/Linux build parity)</li>
+                        <li>[<a href='https://its.cern.ch/jira/browse/OPCUA-3365'>OPCUA-3365</a>] - Set CMake minimum to 3.16, the build's actual requirement</li>
                     </ul>
                     Bug
                     <ul>

--- a/Documentation/source/quasar.rst
+++ b/Documentation/source/quasar.rst
@@ -72,7 +72,7 @@ Installation and Dependencies
 Note: we have specific instructions for the following operating systems:
 
 - AlmaLinux / RHEL (and dependent distributions):
-  - `version 9 <#el9>`__ (e.g. AlmaLinux 9, RHEL 9, ...),
+  - `version 9 <#el9>`__ (e.g. AlmaLinux 9, RHEL 9, ...) and version 10 (e.g. AlmaLinux 10, RHEL 10, ...),
 - `Ubuntu <#ubuntu>`__
 - `MS Windows <#windows>`__
 
@@ -92,7 +92,7 @@ Mandatory:
 
 -  Python3 (3.6 is what we use at minimum) and some libraries (Jinja2, colorama, lxml, pygit2)
 
--  cmake3, version 3.10 + (for older versions you could try older quasar
+-  cmake3, version 3.16 + (for older versions you could try older quasar
    versions)
 
 Recommended:

--- a/FrameworkInternals/OptionalModule.cmake
+++ b/FrameworkInternals/OptionalModule.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.26)
+cmake_minimum_required(VERSION 3.16)
 
 #message ("Configuring optional module ${OPT_MODULE_NAME}")
 project(${OPT_MODULE_NAME}_download NONE)

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ Generated C++ source (AddressSpace, Device bases, Configuration, CMake)
 <summary>Prerequisites</summary>
 
 - Python 3 with lxml, Jinja2, colorama
-- CMake 3.10+
-- C++17 compiler
+- CMake 3.16+
+- C++11 compiler
 - Boost
 - xsdcxx (CodeSynthesis XSD)
 


### PR DESCRIPTION
## What
Lowers quasar's required CMake from **3.26** back to **3.16** (root `CMakeLists.txt` and `FrameworkInternals/OptionalModule.cmake`), and aligns the documentation that had drifted out of sync.

## Why
Nothing in the build needs 3.26. The real floor is **3.15** (`list(PREPEND)` in `CMakeLists.txt`); everything else tops out at 3.12. 3.26 was the AlmaLinux 9 platform default introduced in OPCUA-3326 as a support-baseline, **not** a feature requirement. It blocked developers on older-but-supported CMake — and the prerequisites docs *advertised* "3.10+", so the 3.26 gate violated quasar's own documented contract.

A floor of 3.16 is a strict superset of the platforms OPCUA-3326 targeted (Alma 9 = 3.26, Alma 10 = 3.30+, WS25 = 4.x are all above it) while welcoming older dev machines. CI keeps building on the platform CMakes; the declared floor reflects only the code's real requirement.

## Verified with Docker
| Image | CMake | Before (3.26) | After (3.16) |
|---|---|---|---|
| `ubuntu:20.04` | 3.16.3 | ❌ `CMake 3.26 or higher is required` | ✅ version gate passes |
| `almalinux:9` | 3.26+ | ✅ passes | ✅ passes |

## Changes
- `CMakeLists.txt`, `FrameworkInternals/OptionalModule.cmake`: `3.26 → 3.16` (+ comment so it isn't silently re-bumped)
- `Documentation/source/quasar.rst`, `README.md`: documented minimum `3.10+ → 3.16+`
- `README.md`: `C++17 → C++11` (matches `quasar.rst` and the code's actual C++11 pins)
- `Documentation/source/quasar.rst`: add **AlmaLinux 10** to the supported-OS list (matches CI)
- `Documentation/source/ChangeLog.rst`: v2.0.0 entry now states 3.16; OPCUA-3326 line reworded as the Boost/Windows modernization, OPCUA-3365 credited

Refs OPCUA-3365 (and OPCUA-3326).
