### PR TITLE
OPCUA-3366: Make code generation write-if-different (stop spurious rebuilds)

### DIFF
--- a/FrameworkInternals/generateCmake.py
+++ b/FrameworkInternals/generateCmake.py
@@ -68,7 +68,7 @@ def generateCmake(context, *args):
     merge_user_and_meta_design(
         user_file   = open(mode='r', encoding='utf-8', file=os.path.join(projectSourceDir, 'Design', 'Design.xml')),
         meta_file   = open(mode='r', encoding='utf-8', file=os.path.join(projectSourceDir, 'Meta',   'design', 'meta-design.xml')),
-        merged_file = open(mode='w', encoding='utf-8', file=os.path.join(projectBinaryDir, 'Design', 'DesignWithMeta.xml'))
+        merged_file = os.path.join(projectBinaryDir, 'Design', 'DesignWithMeta.xml')
     )
 
     transformByKey(TransformKeys.AS_CMAKE,     {'context':context})

--- a/FrameworkInternals/manage_files.py
+++ b/FrameworkInternals/manage_files.py
@@ -520,7 +520,7 @@ def _style_it(file_path, vcs):
     with open(file_path, 'rb') as file:
         unindented_content = file.read()
     with open(file_path, 'wb') as file:
-        run_indent_tool(unindented_content, file)
+        file.write(run_indent_tool(unindented_content))
     if vcs.file_has_uncommitted_changes(file_path):
         print (f'{file_path}: {Fore.GREEN}Style fixed, commit if happy.{Style.RESET_ALL}')
     else:

--- a/FrameworkInternals/merge_design_and_meta.py
+++ b/FrameworkInternals/merge_design_and_meta.py
@@ -36,6 +36,7 @@ import sys
 import logging
 import argparse
 from lxml import etree
+from transformDesign import write_if_different
 
 QUASAR_NAMESPACES = {'d':'http://cern.ch/quasar/Design'}
 
@@ -78,12 +79,25 @@ class MergedDesign():
         logging.debug(f"merged design [\n{etree.tostring(self.merged_design, pretty_print=True)}\n]")
 
     def write_to_file(self, output_file):
-        """writes merged design file (user + meta) to disk"""
+        """writes merged design file (user + meta) to disk.
+
+        output_file may be a destination PATH (str) or an already-open text
+        handle. With a path the write is skipped when the destination already
+        holds the identical bytes: the merge is a deterministic function of its
+        inputs, so rewriting byte-identical DesignWithMeta.xml only refreshes its
+        mtime and makes CMake/make rebuild on an unchanged design (OPCUA-3366). A
+        path is required for that, because the compare must happen BEFORE the
+        destination is truncated; a handle pre-opened in 'w' (the standalone
+        process_args path) has already lost the old content, so that legacy form
+        keeps the original unconditional write."""
         logging.info(f"writing file to [{output_file}]")
         content = etree.ElementTree(element=self.merged_design)
-        xml_string = etree.tostring(content, encoding='utf-8', method='xml', pretty_print=True, xml_declaration=True)
-        logging.debug(f"content of XML file [\n{xml_string.decode('utf-8')}\n]")
-        output_file.write(xml_string.decode('utf-8'))
+        xml_bytes = etree.tostring(content, encoding='utf-8', method='xml', pretty_print=True, xml_declaration=True)
+        logging.debug(f"content of XML file [\n{xml_bytes.decode('utf-8')}\n]")
+        if hasattr(output_file, 'write'):  # legacy: caller-pre-opened text handle
+            output_file.write(xml_bytes.decode('utf-8'))
+        else:
+            write_if_different(output_file, xml_bytes)
 
 
 def merge_user_and_meta_design(user_file, meta_file, merged_file):

--- a/FrameworkInternals/transformDesign.py
+++ b/FrameworkInternals/transformDesign.py
@@ -109,10 +109,28 @@ def transformDesignVerbose(transformPath, designXmlPath, outputFile, skipIfExist
                 .format('additionalParam=[{0}]'.format(additionalParam) if additionalParam is not None else ''))
     return transformDesign(transformPath, designXmlPath, outputFile, skipIfExists, astyleRun, additionalParam)
 
-def run_indent_tool(unindented_content, fout):
-    """Runs indentation tool, preferably astyle.
-       unindented_content - stream of bytes (e.g. encoded string) to pass to the tool,
-       fout - a file object to which the output will be written"""
+def write_if_different(outputFile, content):
+    """Write `content` (bytes) to `outputFile` only if it differs from what is
+    already there, and return the number of bytes `outputFile` holds afterwards.
+
+    quasar codegen is a deterministic function of Design.xml, so rewriting
+    byte-identical content just refreshes the mtime and makes CMake/make rebuild
+    everything on an unchanged design (OPCUA-3366). The compare and the write are
+    both binary so there is no newline/encoding translation (Windows-safe), and a
+    missing destination (first generation) simply writes."""
+    try:
+        with open(outputFile, 'rb') as fin:
+            existing = fin.read()
+    except FileNotFoundError:
+        existing = None
+    if existing != content:
+        with open(outputFile, 'wb') as fout:
+            fout.write(content)
+    return len(content)
+
+def run_indent_tool(unindented_content):
+    """Runs indentation tool, preferably astyle, and returns the indented bytes.
+       unindented_content - stream of bytes (e.g. encoded string) to pass to the tool"""
     try:
         astyle_version_check_process = subprocess.run(['astyle', '--version'],
                                                           stderr=subprocess.PIPE,
@@ -143,7 +161,7 @@ def run_indent_tool(unindented_content, fout):
             raise Exception(("None of supported indent tools - astyle or indent - was found. Can't "
                              "continue. Please see quasar documentation on organizing "
                              "dependencies."))
-    fout.write(completed_indenter_process.stdout)
+    return completed_indenter_process.stdout
 
 def handle_abort(msg):
     raise Exception(f'Quasar transform exception:  {msg}') # TODO shall we have a better exc class for it ?
@@ -166,25 +184,26 @@ def transformDesignByJinja(designXmlPath, transformPath, outputFile, additionalP
     transform_filters.setup_all_filters(env)
     env.trim_blocks = True
     env.globals['abort'] = handle_abort
-    fout = open(outputFile, 'wb')
     render_args = {'designInspector':designInspector, 'oracle':Oracle()}
     if not isinstance(additionalParam, dict):
         render_args.update({'additionalParam':additionalParam})
     else:
         render_args.update(additionalParam)
     unindented_content = env.get_template(os.path.basename(transformPath)).render(render_args).encode('utf-8')
+    # write-if-different on the FINAL bytes (post-astyle when indent_cpp), so an
+    # unchanged design does not refresh the output's mtime (OPCUA-3366).
     if indent_cpp:
-        run_indent_tool(unindented_content, fout)
+        written = write_if_different(outputFile, run_indent_tool(unindented_content))
         print(Fore.BLUE +
             'quasar Jinja2 generator: Generated+indented {0}, wrote {1} bytes (unindented size: {2})'.format(
                 outputFile,
-                fout.tell(),
+                written,
                 len(unindented_content)) +
             Style.RESET_ALL)
     else:
-        fout.write(unindented_content)
+        written = write_if_different(outputFile, unindented_content)
         print(Fore.BLUE +
-            'quasar Jinja2 generator: Generated {0}, wrote {1} bytes'.format(outputFile, fout.tell()) +
+            'quasar Jinja2 generator: Generated {0}, wrote {1} bytes'.format(outputFile, written) +
             Style.RESET_ALL)
 
 def transformDesign(transform_path, designXmlPath, outputFile, skipIfExists=False, astyleRun=False, additionalParam=None, requiresMerge=None):


### PR DESCRIPTION
## What
Makes quasar's code generation **write-if-different**: a build with an unchanged `Design.xml` no longer rewrites byte-identical generated files with a fresh mtime, so CMake/make stop rebuilding everything (OPCUA-3366). Turns the `framework_invariants` job (currently red on master) green.

## The fix — +49/-16, 4 files, one shared helper
- **`transformDesign.py`** — new `write_if_different(path, bytes)` (binary compare → Windows-safe; first generation writes); `run_indent_tool` now *returns* the indented bytes; `transformDesignByJinja` compares the **final** (post-astyle) bytes before writing.
- **`merge_design_and_meta.py`** — `write_to_file` takes a path and write-if-differents (the merge must own its destination to compare *before* truncating); legacy pre-opened-handle form kept for the standalone `process_args` path.
- **`generateCmake.py`** — pass the merge destination as a path (1 line).
- **`manage_files.py`** — adapt `_style_it` to `run_indent_tool`'s new return value (1 line).

Generated **content is unchanged** — only redundant writes are skipped.

## Testing
- **Flips the landed test green:** `.CI/test_no_spurious_rebuild.py` (red on master) now passes; `.CI/test_upgrade_override.py` still passes.
- **Byte-identical content:** 7 representative outputs (astyle C++, plain XML/cmake, the merge) are byte-for-byte identical with vs without the fix.
- **Cross-distro hermetic:** green on AlmaLinux 9 (py3.9), AlmaLinux 10 (py3.12), Ubuntu 24.04 (py3.12).
- **Real end-to-end (alma9 toolchain container):** full `quasar.py build` succeeds; the server's exported NodeSet2 **matches the golden reference**; build → rebuild with no change → **0 Design-derived recompiles** (only env-derived `MetaBuildInfo` rebuilds, which is correct), 0 generated sources rewritten.
- Edge cases: first-gen writes, identical skips (mtime kept), changed rewrites, CRLF/NUL binary-exact, partial-write cleanup preserved, all 5 callers safe.

Refs OPCUA-3366.
