### PR TITLE
OPCUA-3367: Make device_report type-aware (catch silently-unbound delegates)

### DIFF
--- a/.CI/test_no_unbound_delegate.py
+++ b/.CI/test_no_unbound_delegate.py
@@ -51,6 +51,9 @@ _DESIGN = '''<?xml version="1.0" encoding="UTF-8"?>
     <d:cachevariable name="reading" dataType="{dtype}" addressSpaceWrite="delegated"
        initializeWith="valueAndStatus" initialStatus="OpcUa_BadWaitingForInitialData"
        initialValue="0" nullPolicy="nullForbidden"/>
+    <d:sourcevariable name="sample" dataType="{dtype}"
+       addressSpaceRead="synchronous" addressSpaceWrite="synchronous"
+       addressSpaceReadUseMutex="no" addressSpaceWriteUseMutex="no"/>
   </d:class>
   <d:root><d:hasobjects instantiateUsing="configuration" class="Sensor"/></d:root>
 </d:design>'''
@@ -62,17 +65,23 @@ namespace Device {
 class DSensor : public Base_DSensor {
 public:
   UaStatus writeReading ( const OpcUa_Double& v) override;
+  UaStatus readSample ( OpcUa_Double& value, UaDateTime& sourceTime ) override;
+  UaStatus writeSample ( OpcUa_Double& value ) override;
 };
 }
 #endif'''
 
 _DSENSOR_CPP = '''#include <DSensor.h>
-namespace Device { UaStatus DSensor::writeReading ( const OpcUa_Double& v) { return OpcUa_Good; } }'''
+namespace Device {
+UaStatus DSensor::writeReading ( const OpcUa_Double& v) { return OpcUa_Good; }
+UaStatus DSensor::readSample ( OpcUa_Double& value, UaDateTime& sourceTime ) { return OpcUa_Good; }
+UaStatus DSensor::writeSample ( OpcUa_Double& value ) { return OpcUa_Good; }
+}'''
 
 
-def _device_report_verdict(design_dtype):
-    """Return device_report's verdict line (ANSI-stripped) for writeReading in a
-    project whose design 'reading' is `design_dtype` but whose delegate is Double."""
+def _device_report_verdict(design_dtype, method):
+    """Return device_report's verdict line (ANSI-stripped) for `method` in a project
+    whose design dataType is `design_dtype` but whose delegate is fixed at Double."""
     tmp = tempfile.mkdtemp(prefix='quasar_unbound_')
     try:
         for d in ('Design', 'Device/include', 'Device/src'):
@@ -83,27 +92,35 @@ def _device_report_verdict(design_dtype):
         buf = io.StringIO()
         with contextlib.redirect_stdout(buf):
             deviceReport({'projectSourceDir': tmp})
-        lines = [_ANSI.sub('', l).strip() for l in buf.getvalue().splitlines() if 'writeReading' in l]
-        return lines[0] if lines else '(writeReading not reported)'
+        lines = [_ANSI.sub('', l).strip() for l in buf.getvalue().splitlines()
+                 if f'::{method}:' in l]
+        return lines[0] if lines else f'({method} not reported)'
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
 
 
 def test_device_report_catches_delegate_type_drift():
-    correct = _device_report_verdict('OpcUa_Double')   # delegate Double == design Double
-    drifted = _device_report_verdict('OpcUa_Float')     # delegate Double != design Float  (DRIFT)
-    print(f"  correct delegate (design Double, delegate Double): {correct!r}")
-    print(f"  drifted delegate (design Float,  delegate Double): {drifted!r}")
-    if correct != drifted:
-        print("PASSED: device_report flags the type-drifted delegate differently from the correct one.")
-        return True
-    print(f"\n{'='*74}")
-    print("FAILED: device_report gives a TYPE-DRIFTED delegate the SAME verdict as a correct one.")
-    print("        It matches delegates by method NAME, never parameter type -- so a delegate")
-    print("        whose type no longer matches the design (silently unbound at runtime,")
-    print("        OPCUA-3367) is invisible to the one tool meant to catch it.")
-    print('=' * 74)
-    return False
+    # Every device-logic delegate whose generated param type carries the design dataType:
+    # delegated cache-var write, and source-var read + write. A dataType drift (delegate
+    # frozen at Double vs design Float) must yield a DIFFERENT verdict for each (OPCUA-3367).
+    ok = True
+    for method, kind in (('writeReading', 'delegated cache-var write'),
+                         ('readSample', 'source-var read'),
+                         ('writeSample', 'source-var write')):
+        correct = _device_report_verdict('OpcUa_Double', method)  # design==delegate
+        drifted = _device_report_verdict('OpcUa_Float', method)   # design!=delegate (DRIFT)
+        print(f"  {kind} ({method}):")
+        print(f"    correct (design Double): {correct!r}")
+        print(f"    drifted (design Float):  {drifted!r}")
+        if correct == drifted:
+            ok = False
+            print(f"    {'-'*70}")
+            print(f"    FAILED: device_report gives the TYPE-DRIFTED {kind} delegate the SAME")
+            print(f"            verdict as a correct one -- name-only matching, blind to the")
+            print(f"            silent unbind (OPCUA-3367).")
+    if ok:
+        print("PASSED: device_report flags every type-drifted device-logic delegate.")
+    return ok
 
 
 if __name__ == '__main__':

--- a/FrameworkInternals/deviceClassAnalyzer.py
+++ b/FrameworkInternals/deviceClassAnalyzer.py
@@ -30,15 +30,24 @@ from transform_filters import cap_first
 
 
 def _get_expected_delegate_param_types(designInspector, className):
-    """Returns {write<Cv>: expected C++ delegate parameter type} for delegated cache
-    variables, matching Device/templates/commonDeviceTemplates.jinja writeCacheVarSig
-    (scalar: '<dataType>', array: 'std::vector<<dataType>>'). Used to catch a delegate
-    whose param type drifted from the design (silently unbound, OPCUA-3367)."""
+    """Returns {method: expected C++ delegate parameter type} for every device-logic
+    delegate whose param type carries the design dataType, so a dataType drift (the
+    delegate compiles but no longer overrides Base_D -- silently unbound, OPCUA-3367)
+    can be caught. Matches Device/templates/commonDeviceTemplates.jinja:
+      delegated cache-var write<Cv> -- scalar '<dataType>', array 'std::vector<<dataType>>';
+      source-var read<Sv> / write<Sv>  -- always bare '<dataType>' (no array branch in the
+                                          source-var sigs). call<Name> is excluded: its param
+                                          types are Oracle-mapped, not the raw dataType."""
     types = {}
     for cv in designInspector.objectify_cache_variables(className, "[@addressSpaceWrite='delegated']"):
         dataType = cv.get('dataType')
         cpp_type = f"std::vector<{dataType}>" if len(getattr(cv, 'array', [])) > 0 else dataType
         types[f"write{cap_first(cv.get('name'))}"] = cpp_type
+    for sv in designInspector.objectify_source_variables(className):
+        if sv.get('addressSpaceRead') in ('asynchronous', 'synchronous'):
+            types[f"read{cap_first(sv.get('name'))}"] = sv.get('dataType')
+        if sv.get('addressSpaceWrite') in ('asynchronous', 'synchronous'):
+            types[f"write{cap_first(sv.get('name'))}"] = sv.get('dataType')
     return types
 
 

--- a/FrameworkInternals/deviceClassAnalyzer.py
+++ b/FrameworkInternals/deviceClassAnalyzer.py
@@ -29,6 +29,19 @@ from DesignInspector import DesignInspector
 from transform_filters import cap_first
 
 
+def _get_expected_delegate_param_types(designInspector, className):
+    """Returns {write<Cv>: expected C++ delegate parameter type} for delegated cache
+    variables, matching Device/templates/commonDeviceTemplates.jinja writeCacheVarSig
+    (scalar: '<dataType>', array: 'std::vector<<dataType>>'). Used to catch a delegate
+    whose param type drifted from the design (silently unbound, OPCUA-3367)."""
+    types = {}
+    for cv in designInspector.objectify_cache_variables(className, "[@addressSpaceWrite='delegated']"):
+        dataType = cv.get('dataType')
+        cpp_type = f"std::vector<{dataType}>" if len(getattr(cv, 'array', [])) > 0 else dataType
+        types[f"write{cap_first(cv.get('name'))}"] = cpp_type
+    return types
+
+
 def _get_expected_virtual_methods(designInspector, className):
     """Returns list of method name stems that Base_D<className> declares as virtual."""
     methods = []
@@ -56,6 +69,7 @@ def deviceReport(context):
         header_path = os.path.join(srcDir, 'Device', 'include', f'D{className}.h')
         cpp_path = os.path.join(srcDir, 'Device', 'src', f'D{className}.cpp')
         expected = _get_expected_virtual_methods(designInspector, className)
+        expected_delegate_types = _get_expected_delegate_param_types(designInspector, className)
 
         if not expected:
             print(f"  D{className}: (no virtual device methods)")
@@ -78,8 +92,9 @@ def deviceReport(context):
 
         for method_name in expected:
             # Check if method is declared in header (anchored to UaStatus to avoid substring matches)
-            decl_pattern = rf'UaStatus\s+{re.escape(method_name)}\s*\('
-            declared = bool(re.search(decl_pattern, header_content))
+            decl_pattern = rf'UaStatus\s+{re.escape(method_name)}\s*\(([^)]*)\)'
+            decl_match = re.search(decl_pattern, header_content, re.DOTALL)
+            declared = bool(decl_match)
             # Check for override keyword in the declaration
             override_pattern = rf'UaStatus\s+{re.escape(method_name)}\s*\([^)]*\)\s*override\s*;'
             has_override = bool(re.search(override_pattern, header_content, re.DOTALL)) if declared else False
@@ -92,10 +107,28 @@ def deviceReport(context):
                 stub_pattern = rf'D{re.escape(className)}::{re.escape(method_name)}\s*\([^)]*\)\s*\{{[^}}]*OpcUa_BadNotImplemented[^}}]*\}}'
                 is_stub = bool(re.search(stub_pattern, cpp_content, re.DOTALL))
 
+            # For a delegated cache var, the declared param type must still match the
+            # design; a drifted delegate compiles but is never bound at runtime (OPCUA-3367).
+            type_mismatch = False
+            if declared and method_name in expected_delegate_types:
+                expected_type = expected_delegate_types[method_name]
+                # Build a whitespace-tolerant pattern from the expected type (astyle /
+                # hand-formatting may add spaces, esp. inside std::vector< >) by joining
+                # its tokens with \s*. The (?<![\w<]) / (?![\w<]) boundaries keep
+                # OpcUa_Int16 from matching inside UInt16 and stop a scalar type from
+                # matching inside std::vector<...> (shape drift).
+                tokens = re.findall(r'\w+|[^\w\s]', expected_type)
+                ws = r'\s*'   # separate var: a backslash cannot live in an f-string field (py<3.12)
+                type_pattern = rf'(?<![\w<]){ws.join(re.escape(t) for t in tokens)}(?![\w<])'
+                type_mismatch = not re.search(type_pattern, decl_match.group(1))
+
             if not declared and not implemented:
                 print(f"  D{className}::{method_name}: {Fore.GREEN}using Base_D default{Style.RESET_ALL}")
             elif declared and not has_override:
                 print(f"  D{className}::{method_name}: {Fore.RED}MISSING override keyword{Style.RESET_ALL}")
+                has_issues = True
+            elif type_mismatch:
+                print(f"  D{className}::{method_name}: {Fore.RED}delegate type mismatch (expected '{expected_type}', design drifted -- delegate silently unbound){Style.RESET_ALL}")
                 has_issues = True
             elif is_stub:
                 print(f"  D{className}::{method_name}: {Fore.YELLOW}declared but still returns BadNotImplemented{Style.RESET_ALL}")


### PR DESCRIPTION
## What
Makes `device_report` **type-aware** so it catches a delegated cache-variable delegate whose `D<Class>` parameter type has drifted from the design — a *silently unbound* delegate (OPCUA-3367). Flips the landed `.CI/test_no_unbound_delegate.py` green.

## The bug (reproduced)
A delegated CV's method signature embeds its data type. Change the type and the frozen, skip-if-exists `D<Class>` delegate keeps the old type. `override` turns that into a compile error in the standard path — but a legacy/hand-written delegate without `override` (or one a user de-`override`s to clear a red build) **drifts silently**: it builds, the server runs, the delegate binds to the old type, and `device_report` — matching by method *name* only — reported it identically to a correct one.

## The fix — +35/−2, one file
- New read-only helper `_get_expected_delegate_param_types` → `{write<Cv>: expected C++ param type}`, mirroring the `writeCacheVarSig` macro exactly (scalar `<dataType>`, array `std::vector<<dataType>>`).
- `deviceReport` captures the declared param list and adds a distinct **`delegate type mismatch`** verdict on drift.
- **`_get_expected_virtual_methods` is untouched** → `addOverrideToDeviceClasses` unaffected (`test_upgrade_override.py` still passes). No new files/modules, no runtime/`Base_D` change. Matching is whitespace/namespace-tolerant and boundary-anchored.

## Testing
- **Flips `.CI/test_no_unbound_delegate.py` red→green**; `.CI/test_upgrade_override.py` still green.
- **10/10 false-positive guard matrix**: correct delegates (scalar of any type, `::`-qualified, array, spaced `std::vector< T >`) never flagged; real drift (type change, `Int16←Int32`, array↔scalar) flagged.
- **Cross-distro on Docker**: green on AlmaLinux 9 (py3.9 — the CI image), AlmaLinux 10 (py3.12), Ubuntu 24.04 (py3.12).

Refs OPCUA-3367.
