### PR TITLE
OPCUA-3384 Bump open62541-compat pin to v1.4.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 env:
-  OPEN62541_COMPAT_VERSION: v1.4.3-rc0
+  OPEN62541_COMPAT_VERSION: v1.4.6
 
 jobs:
 


### PR DESCRIPTION
Bumps the open62541-compat pin used by all open62541 CI jobs from `v1.4.3-rc0` to `v1.4.6`.

`v1.4.6` (just tagged) contains OPCUA-3384, which removes `-Werror` from the vendored open62541 amalgamation's C flags. That `-Werror` made newer compilers (clang 21, gcc 16) fatally fail building third-party upstream code, and was the 33% link wall hit by the clang hardening in OPCUA-3341.

With this bump, an end-to-end quasar open62541 `OpcUaServer` links under clang (verified locally against v1.4.6). `v1.4.6` also carries v1.4.4/v1.4.5 (incl. the OPCUA-3381 gcc16 source-level warning fixes), so it moves the pin off a release candidate onto a current release.

Note: quasar CI has no dedicated clang build job, so the benefit here is that clang/gcc16 builds work end-to-end; the existing gcc open62541 jobs continue to run against v1.4.6. Watching this PR's CI to confirm no behavioural change in the o6 jobs from the version jump.
