### PR TITLE
OPCUA-3341 Add clang + open62541 CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,27 @@ jobs:
           --open62541_compat_branch ${{ env.OPEN62541_COMPAT_VERSION }}
           --compare_with_nodeset .CI/test_cases/test_default_quasar_design/reference_ns2.xml
 
+  o6_clang_default_design:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/quasar-team/quasar-uasdk:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      CC: clang
+      CXX: clang++
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - run: dnf install -y clang
+      - run: >
+          .CI/run_test_case.py
+          --opcua_backend o6
+          --open62541_compat_branch ${{ env.OPEN62541_COMPAT_VERSION }}
+          --compare_with_nodeset .CI/test_cases/test_default_quasar_design/reference_ns2.xml
+
   o6_cache_variables:
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
Adds `o6_clang_default_design`: builds the default design under **clang** against the **open62541** backend, runs the server, and diffs the address space against the reference. It runs in parallel with the existing gcc jobs and continuously guards the clang / glibc-free hardening (OPCUA-3341) plus the open62541-compat amalgamation fix (OPCUA-3384) instead of relying on one-off local proofs.

Mirrors `o6_default_design` with `CC=clang CXX=clang++` and a `dnf install -y clang` step. AlmaLinux 9 (the `quasar-uasdk:latest` image) ships clang 21.1.8, and the v1.4.6 open62541-compat pin no longer compiles the vendored amalgamation with `-Werror`, so the clang build links end to end. The generated address space is compiler-independent, so it diffs against the same `test_default_quasar_design/reference_ns2.xml` as the gcc job.
