### PR TITLE
OPCUA-3341 Add clang + open62541 CI job (clang-15)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,27 @@ jobs:
           --open62541_compat_branch ${{ env.OPEN62541_COMPAT_VERSION }}
           --compare_with_nodeset .CI/test_cases/test_default_quasar_design/reference_ns2.xml
 
+  o6_clang_default_design:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/quasar-team/quasar-uasdk:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      CC: clang-15
+      CXX: clang++-15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - run: dnf install -y clang15
+      - run: >
+          .CI/run_test_case.py
+          --opcua_backend o6
+          --open62541_compat_branch ${{ env.OPEN62541_COMPAT_VERSION }}
+          --compare_with_nodeset .CI/test_cases/test_default_quasar_design/reference_ns2.xml
+
   o6_cache_variables:
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
Adds `o6_clang_default_design`: builds the default design under **clang** against the **open62541** backend and diffs the address space, running in parallel with the gcc jobs. This continuously guards the clang hardening (OPCUA-3341) and the open62541-compat amalgamation fix (OPCUA-3384) instead of relying on one-off local proofs.

Uses the **`clang15`** compat package with `CC=clang-15 CXX=clang++-15`. Rationale: AlmaLinux 9's stock Boost 1.75 does not compile under clang >= 19 (`boost::numeric_cast` trips Boost MPL; clang 19 and 21 both fail, tracked in DCS-602), while clang 15.0.7 builds the full server cleanly. Verified locally on the exact `quasar-uasdk:latest` image with open62541-compat v1.4.6: full `OpcUaServer` link, zero errors, zero warnings.

A previous attempt (#361) used the unversioned `clang` package, which tracks latest (21) and hit the Boost wall; this supersedes it.
