### PR TITLE
OPCUA-3341 Move clang CI job to alma10 (latest clang, unpinned)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,18 +33,18 @@ jobs:
   o6_clang_default_design:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/quasar-team/quasar-uasdk:latest
+      image: ghcr.io/quasar-team/quasar-uasdk:alma10
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     env:
-      CC: clang-15
-      CXX: clang++-15
+      CC: clang
+      CXX: clang++
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - run: dnf install -y clang15
+      - run: dnf install -y clang
       - run: >
           .CI/run_test_case.py
           --opcua_backend o6


### PR DESCRIPTION
Switches `o6_clang_default_design` from the Alma9 image + pinned `clang15` to the **alma10** image + the rolling `clang` package (currently 21.1.8).

Rationale: Alma9's stock Boost 1.75 breaks under clang >= 19 (`boost::numeric_cast` vs Boost MPL, DCS-602), which forced the clang-15 pin. Alma10 ships **Boost 1.83**, which compiles cleanly under current clang, so the job can track the latest clang with no pin to maintain and catches new compiler diagnostics first.

Verified locally on the exact `quasar-uasdk:alma10` image with open62541-compat v1.4.6: full `OpcUaServer` build under clang 21.1.8, zero errors, zero warnings, binary linked.