### PR TITLE
Dispatch open62541-backend source variables & async methods on the thread pool

### DIFF
--- a/AddressSpace/include/ASSourceVariable.h
+++ b/AddressSpace/include/ASSourceVariable.h
@@ -80,7 +80,11 @@ private:
 #else
 
 #include <functional>
+#include <memory>
+#include <mutex>
 #include <opcua_basedatavariabletype.h>
+#include <QuasarThreadPool.h>
+#include <SourceVariables.h>
 
 namespace AddressSpace
 {
@@ -90,6 +94,7 @@ class ASSourceVariable: public OpcUa::BaseDataVariableType
 public:
 	typedef std::function<UaStatus(UaVariant&, UaDateTime&)> ReadFn;
 	typedef std::function<UaStatus(const UaVariant&)> WriteFn;
+	typedef std::function<std::mutex*()> MutexFn;
 
 	ASSourceVariable (
 			const UaNodeId&    nodeId,
@@ -99,11 +104,19 @@ public:
 			OpcUa_Byte         accessLevel,
 			NodeManagerConfig* pNodeConfig,
 			ReadFn             readFn,
+			bool               readAsynchronous,
+			MutexFn            readMutexFn,
 			WriteFn            writeFn,
+			bool               writeAsynchronous,
+			MutexFn            writeMutexFn,
 			UaMutexRefCounted* pSharedMutex = NULL):
 				OpcUa::BaseDataVariableType (nodeId, name, browseNameNameSpaceIndex, initialValue, accessLevel, pNodeConfig, pSharedMutex),
 				m_readFn(readFn),
-				m_writeFn(writeFn)
+				m_writeFn(writeFn),
+				m_readMutexFn(readMutexFn),
+				m_writeMutexFn(writeMutexFn),
+				m_readAsynchronous(readAsynchronous),
+				m_writeAsynchronous(writeAsynchronous)
 			{}
 
 	virtual UaDataValue value (Session* session) override
@@ -129,9 +142,147 @@ public:
 			return OpcUa::BaseDataVariableType::setValue(session, dataValue, checkAccessLevel);
 	}
 
+	virtual OpcUa_Boolean handlesIo () const override { return OpcUa_True; }
+
+	virtual void beginRead (AsyncReadHandle handle) override
+	{
+		if (!m_readFn)
+		{
+			handle.complete(OpcUa::BaseDataVariableType::value(nullptr));
+			return;
+		}
+		std::mutex* mutex = nullptr;
+		if (m_readMutexFn)
+		{
+			mutex = m_readMutexFn();
+			if (!mutex)
+			{
+				handle.complete(badDataValue(OpcUa_BadInternalError));
+				return;
+			}
+		}
+		ReadFn readFn = m_readFn;
+		UaString address = nodeId().toString();
+		auto work = [readFn, address]() -> UaDataValue
+		{
+			UaVariant variant;
+			UaDateTime sourceTime;
+			UaStatus status;
+			try
+			{
+				status = readFn(variant, sourceTime);
+			}
+			catch (const std::exception& e)
+			{
+				LOG(Log::ERR) << "At variable " << address.toUtf8() << " an exception was thrown from the read delegate: " << e.what();
+				status = OpcUa_BadInternalError;
+			}
+			catch (...)
+			{
+				LOG(Log::ERR) << "At variable " << address.toUtf8() << " a non-standard exception was thrown from the read delegate";
+				status = OpcUa_BadInternalError;
+			}
+			return UaDataValue(variant, status.statusCode(), sourceTime, UaDateTime::now());
+		};
+		if (m_readAsynchronous)
+		{
+			Quasar::ThreadPool* pool = SourceVariables_getThreadPool();
+			std::shared_ptr<AsyncReadHandle> sharedHandle(new AsyncReadHandle(std::move(handle)));
+			UaStatus dispatchStatus = pool
+				? pool->addJob(
+					[work, sharedHandle](){ sharedHandle->complete(work()); },
+					std::string("read sourcevariable of node ") + address.toUtf8(),
+					mutex)
+				: UaStatus(OpcUa_BadOutOfService);
+			if (!dispatchStatus.isGood())
+				sharedHandle->complete(badDataValue(dispatchStatus.statusCode()));
+		}
+		else
+		{
+			if (mutex)
+			{
+				std::unique_lock<std::mutex> lock(*mutex);
+				handle.complete(work());
+			}
+			else
+				handle.complete(work());
+		}
+	}
+
+	virtual void beginWrite (const UaDataValue& dataValue, AsyncWriteHandle handle) override
+	{
+		if (!m_writeFn)
+		{
+			handle.complete(OpcUa::BaseDataVariableType::setValue(nullptr, dataValue, OpcUa_True));
+			return;
+		}
+		std::mutex* mutex = nullptr;
+		if (m_writeMutexFn)
+		{
+			mutex = m_writeMutexFn();
+			if (!mutex)
+			{
+				handle.complete(OpcUa_BadInternalError);
+				return;
+			}
+		}
+		WriteFn writeFn = m_writeFn;
+		UaString address = nodeId().toString();
+		UaVariant variant(*dataValue.value());
+		auto work = [writeFn, address, variant]() -> UaStatus
+		{
+			try
+			{
+				return writeFn(variant);
+			}
+			catch (const std::exception& e)
+			{
+				LOG(Log::ERR) << "At variable " << address.toUtf8() << " an exception was thrown from the write delegate: " << e.what();
+				return OpcUa_BadInternalError;
+			}
+			catch (...)
+			{
+				LOG(Log::ERR) << "At variable " << address.toUtf8() << " a non-standard exception was thrown from the write delegate";
+				return OpcUa_BadInternalError;
+			}
+		};
+		if (m_writeAsynchronous)
+		{
+			Quasar::ThreadPool* pool = SourceVariables_getThreadPool();
+			std::shared_ptr<AsyncWriteHandle> sharedHandle(new AsyncWriteHandle(std::move(handle)));
+			UaStatus dispatchStatus = pool
+				? pool->addJob(
+					[work, sharedHandle](){ sharedHandle->complete(work()); },
+					std::string("write sourcevariable of node ") + address.toUtf8(),
+					mutex)
+				: UaStatus(OpcUa_BadOutOfService);
+			if (!dispatchStatus.isGood())
+				sharedHandle->complete(dispatchStatus);
+		}
+		else
+		{
+			if (mutex)
+			{
+				std::unique_lock<std::mutex> lock(*mutex);
+				handle.complete(work());
+			}
+			else
+				handle.complete(work());
+		}
+	}
+
 private:
+	static UaDataValue badDataValue (OpcUa_StatusCode status)
+	{
+		return UaDataValue(UaVariant(), status, UaDateTime::now(), UaDateTime::now());
+	}
+
 	ReadFn m_readFn;
 	WriteFn m_writeFn;
+	MutexFn m_readMutexFn;
+	MutexFn m_writeMutexFn;
+	bool m_readAsynchronous;
+	bool m_writeAsynchronous;
 };
 
 }

--- a/AddressSpace/templates/designToClassBody.jinja
+++ b/AddressSpace/templates/designToClassBody.jinja
@@ -352,6 +352,22 @@ std::string decorateSingleVariableNodeName (const std::string& basicName, bool i
             return s;
           },
           {% endif %}
+          {{ 'true' if sv.get('addressSpaceRead') == 'asynchronous' else 'false' }},
+          {% if sv.get('addressSpaceRead') == 'forbidden' or sv.get('addressSpaceReadUseMutex') in ['no', None] %}
+          ASSourceVariable::MutexFn(),
+          {% elif sv.get('addressSpaceReadUseMutex') == 'of_this_operation' %}
+          [this]() -> std::mutex* { Device::D{{className}}* deviceLink = getDeviceLink(); return deviceLink ? &deviceLink->getLockVariableRead_{{sv.get('name')}}() : nullptr; },
+          {% elif sv.get('addressSpaceReadUseMutex') == 'of_this_variable' %}
+          [this]() -> std::mutex* { Device::D{{className}}* deviceLink = getDeviceLink(); return deviceLink ? &deviceLink->getLockVariable_{{sv.get('name')}}() : nullptr; },
+          {% elif sv.get('addressSpaceReadUseMutex') == 'of_containing_object' %}
+          [this]() -> std::mutex* { Device::D{{className}}* deviceLink = getDeviceLink(); return deviceLink ? &deviceLink->getLock() : nullptr; },
+          {% elif sv.get('addressSpaceReadUseMutex') == 'of_parent_of_containing_object' %}
+          [this]() -> std::mutex* { Device::D{{className}}* deviceLink = getDeviceLink(); return (deviceLink && deviceLink->getParent()) ? &deviceLink->getParent()->getLock() : nullptr; },
+          {% elif sv.get('addressSpaceReadUseMutex') == 'handpicked' %}
+          [this]() -> std::mutex* { return this->fetchReadMutexOf{{sv.get('name')|capFirst}}(); },
+          {% else %}
+          {{ abort('invalid mode addressSpaceReadUseMutex: ' + sv.get('addressSpaceReadUseMutex')) }}
+          {% endif %}
           {% if sv.get('addressSpaceWrite') == 'forbidden' %}
           ASSourceVariable::WriteFn()
           {% else %}
@@ -376,6 +392,23 @@ std::string decorateSingleVariableNodeName (const std::string& basicName, bool i
             {% endif %}
             return deviceLink->write{{sv.get('name')|capFirst}}( value );
           }
+          {% endif %}
+          ,
+          {{ 'true' if sv.get('addressSpaceWrite') == 'asynchronous' else 'false' }},
+          {% if sv.get('addressSpaceWrite') == 'forbidden' or sv.get('addressSpaceWriteUseMutex') in ['no', None] %}
+          ASSourceVariable::MutexFn()
+          {% elif sv.get('addressSpaceWriteUseMutex') == 'of_this_operation' %}
+          [this]() -> std::mutex* { Device::D{{className}}* deviceLink = getDeviceLink(); return deviceLink ? &deviceLink->getLockVariableWrite_{{sv.get('name')}}() : nullptr; }
+          {% elif sv.get('addressSpaceWriteUseMutex') == 'of_this_variable' %}
+          [this]() -> std::mutex* { Device::D{{className}}* deviceLink = getDeviceLink(); return deviceLink ? &deviceLink->getLockVariable_{{sv.get('name')}}() : nullptr; }
+          {% elif sv.get('addressSpaceWriteUseMutex') == 'of_containing_object' %}
+          [this]() -> std::mutex* { Device::D{{className}}* deviceLink = getDeviceLink(); return deviceLink ? &deviceLink->getLock() : nullptr; }
+          {% elif sv.get('addressSpaceWriteUseMutex') == 'of_parent_of_containing_object' %}
+          [this]() -> std::mutex* { Device::D{{className}}* deviceLink = getDeviceLink(); return (deviceLink && deviceLink->getParent()) ? &deviceLink->getParent()->getLock() : nullptr; }
+          {% elif sv.get('addressSpaceWriteUseMutex') == 'handpicked' %}
+          [this]() -> std::mutex* { return this->fetchWriteMutexOf{{sv.get('name')|capFirst}}(); }
+          {% else %}
+          {{ abort('invalid mode addressSpaceWriteUseMutex: ' + sv.get('addressSpaceWriteUseMutex')) }}
           {% endif %}
           );
         #endif
@@ -862,8 +895,8 @@ std::string decorateSingleVariableNodeName (const std::string& basicName, bool i
           {% endfor %}
 
           {% if m.get('executionSynchronicity') == 'asynchronous' %}
-            #ifndef BACKEND_OPEN62541
-            AddressSpace::SourceVariables_getThreadPool()->addJob(
+            Quasar::ThreadPool* pool = AddressSpace::SourceVariables_getThreadPool();
+            UaStatus dispatchStatus = !pool ? UaStatus(OpcUa_BadOutOfService) : pool->addJob(
               [this,
               callbackHandle,
               pCallback
@@ -871,7 +904,6 @@ std::string decorateSingleVariableNodeName (const std::string& basicName, bool i
                 ,arg_{{arg.get('name')}}
               {% endfor %}
               ](){
-            #endif
           {% endif %}
 
           {% for rv in m.returnvalue %}
@@ -934,7 +966,6 @@ std::string decorateSingleVariableNodeName (const std::string& basicName, bool i
           }
 
           {% if m.get('executionSynchronicity') == 'asynchronous' %}
-          #ifndef BACKEND_OPEN62541
           }, std::string("method call of method {{m.get('name')}} on object ")+this->nodeId().toString().toUtf8(),
           /*mutex*/
             {%- if m.get('addressSpaceCallUseMutex') == 'of_this_method' -%}
@@ -947,8 +978,14 @@ std::string decorateSingleVariableNodeName (const std::string& basicName, bool i
               {{abort('Invalid setting for addressSpaceCallUseMutex: ' + m.get('addressSpaceCallUseMutex') + ' (at class='+className+', method='+m.get('name')+')'  )}}
             {% endif %}
              );
+          if (!dispatchStatus.isGood())
+          {
+            UaStatusCodeArray dispatchArgResults;
+            UaDiagnosticInfos dispatchArgDiag;
+            UaVariantArray dispatchOutputs;
+            pCallback->finishCall( callbackHandle, dispatchArgResults, dispatchArgDiag, dispatchOutputs, dispatchStatus );
+          }
           return OpcUa_Good;
-          #endif
           {% endif %}
         }
       {% endfor %}

--- a/Meta/src/DSourceVariableThreadPool.cpp
+++ b/Meta/src/DSourceVariableThreadPool.cpp
@@ -58,7 +58,6 @@ DSourceVariableThreadPool::DSourceVariableThreadPool (
     /* fill up constructor initialization list here */
 {
     /* fill up constructor body here */
-  #ifndef BACKEND_OPEN62541
     try
     {
         const std::string minThreads = config.minThreads();
@@ -71,7 +70,6 @@ DSourceVariableThreadPool::DSourceVariableThreadPool (
         LOG(Log::ERR) << __FUNCTION__ << " failed to start source variable thread pool, error: " << e.what();
         throw e;
     }
-  #endif    
 }
 
 /* sample dtr */


### PR DESCRIPTION
## What

Wires the open62541 backend to UA-SDK execution parity (2 commits, rebased onto 2.1.0):

1. **Dispatch** `executionSynchronicity=asynchronous` methods and source-variable read/write through `SourceVariables_getThreadPool()` under `BACKEND_OPEN62541` (was UASDK-only; o6 ran them inline on the iterate thread). Mutex-mode routing for all six design attributes; `addJob` failures complete the call with the pool status instead of hanging the client.
2. **Initialize** the source-variables thread pool for the o6 backend too (`Meta/src/DSourceVariableThreadPool.cpp` was `#ifndef BACKEND_OPEN62541` → null pool → `BadOutOfService` for every deferral under o6).

Depends on the compat deferral API: `quasar-team/open62541-compat#async-parity-open62541-15`.

## Testing

Verified via the docker server×backend parity matrix: source-variable reads and async method bodies execute on pool workers (gdb-confirmed), ms-scale responsiveness during 2 s deferred ops, both same- and cross-session.

Small surface: 6 files, +26/-39 (template + `ASSourceVariable.h` + pool init).