### PR TITLE
Bump open62541-compat pin to v1.5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 env:
-  OPEN62541_COMPAT_VERSION: v1.4.7
+  OPEN62541_COMPAT_VERSION: v1.5.0
 
 jobs:
 


### PR DESCRIPTION
open62541-compat v1.5.0 (open62541 1.5.4, deferred async read/write/call) is required by the source-variable/method dispatch merged in #364 — the o6 CI jobs have been failing on master against the v1.4.7 pin since that merge. This PR's CI matrix is the verification: every `o6_*` job builds against the tagged compat. The `o6_methods` job result also settles OPCUA-3317.