### PR TITLE
Bump open62541-compat pin to v1.5.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 env:
-  OPEN62541_COMPAT_VERSION: v1.5.0
+  OPEN62541_COMPAT_VERSION: v1.5.1
 
 jobs:
 


### PR DESCRIPTION
open62541-compat v1.5.1 carries the UASDK fidelity batch (OPCUA-3400..3405: opcua_p_types.h, UaVariant::dataType(), UaNodeId::operator!=, Boolean spellings, non-throwing toByteString with Byte-array conversion, typed empty arrays). The CI matrix is the regression net.