### PR TITLE
Bump open62541-compat pin to v1.5.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 env:
-  OPEN62541_COMPAT_VERSION: v1.5.1
+  OPEN62541_COMPAT_VERSION: v1.5.2
 
 jobs:
 


### PR DESCRIPTION
Property nodes follow the server under the open62541 backend: browse-name namespace from the node id (OPCUA-3406) and honored access level (OPCUA-3407). CI matrix is the regression net.