### PR TITLE
Bump open62541-compat pin to v1.5.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 env:
-  OPEN62541_COMPAT_VERSION: v1.5.2
+  OPEN62541_COMPAT_VERSION: v1.5.3
 
 jobs:
 


### PR DESCRIPTION
UaNodeId::toFullString()/toString() now follow the UA-SDK formats (OPCUA-3408 — eltek segfault root cause). CI matrix as regression net.