### PR TITLE
Bump open62541-compat pin to v1.5.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 env:
-  OPEN62541_COMPAT_VERSION: v1.5.3
+  OPEN62541_COMPAT_VERSION: v1.5.4
 
 jobs:
 


### PR DESCRIPTION
UA-SDK API surface package (OPCUA-3410: const char* toUtf8(), UaVariable, reference-list lookups, changeType, UaDataValue setters, uathread/uasemaphore/uaobjecttypes/srvtrace headers). CI matrix as regression net — note toUtf8() signature change is covered by the o6 jobs compiling the full framework.