### PR TITLE
OPCUA-3412: define OPCUA_TOOLKIT_COMPAT_LAYER_OBJECTS in open62541_config.cmake (+ compat pin v1.5.5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 env:
-  OPEN62541_COMPAT_VERSION: v1.5.4
+  OPEN62541_COMPAT_VERSION: v1.5.5
 
 jobs:
 

--- a/open62541_config.cmake
+++ b/open62541_config.cmake
@@ -73,3 +73,4 @@ SET( XML_LIBS "-lxerces-c" )
 #Quasar server libs
 #-----
 SET( QUASAR_SERVER_LIBS "-lssl -lcrypto -lpthread" )
+SET( OPCUA_TOOLKIT_COMPAT_LAYER_OBJECTS $<TARGET_OBJECTS:open62541-compat> )


### PR DESCRIPTION
[OPCUA-3412](https://its.cern.ch/jira/browse/OPCUA-3412): server projects whose extra executables embed the toolkit compat-layer objects (caen Device/test, eltek ConfigurationCreation/test) failed to link under the open62541 backend because the config never set the variable — every parity cell had to define it locally. Now points at the open62541-compat OBJECT library. Verified: eltek-opcua-server full clean build (incl. its test executables) + run + probe in the parity harness with the cell-local workaround removed. Also bumps the compat pin to v1.5.5 (UaSession::serverStatus, OPCUA-3413).