### PR TITLE
OPCUA-3128: UaVariant cache variables advertise valueRank -3 (scalar or 1D array)

### DIFF
--- a/AddressSpace/templates/designToClassBody.jinja
+++ b/AddressSpace/templates/designToClassBody.jinja
@@ -147,6 +147,8 @@ std::string decorateSingleVariableNodeName (const std::string& basicName, bool i
             arrayDimensions.create(1);
             m_{{cv.get('name')}}->setArrayDimensions(arrayDimensions);
           }
+        {% elif cv.get('dataType') == 'UaVariant' %}
+          m_{{cv.get('name')}}->setValueRank( -3 ); // scalar or 1D-array
         {% else %}
           m_{{cv.get('name')}}->setValueRank( -1 ); // scalar
         {% endif %}


### PR DESCRIPTION
[OPCUA-3128](https://its.cern.ch/jira/browse/OPCUA-3128) / quasar issue #321: the generated address space set `valueRank = -1` (scalar) on every non-array cache variable **including** `dataType="UaVariant"` — the any-type variable — so clients writing a legal array variant were refused. Empirically this affects **both backends identically** (UA-SDK 1.6.5 enforces the advertised rank just like open62541; the issue's leniency assumption no longer holds). Fix as proposed by the contributor: `UaVariant` cache variables advertise `-3` (ScalarOrOneDimension).

**Verification** (docker parity harness, `UaVariant` cachevar added to the test design, asyncua scalar+array writes):

| | array write @ master | array write @ this PR |
|---|---|---|
| open62541 | BadTypeMismatch | **Good**, readback `[1.5, 2.5, 3.5]` |
| UA-SDK 1.6.5 | BadTypeMismatch | **Good**, readback `[1.5, 2.5, 3.5]` |

Scalar writes Good in all four quadrants; behavior change is symmetric, parity preserved by construction.