### PR TITLE
Pin vendored LogIt to the v1.0.x maintenance branch (+ compat pin v1.5.6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 env:
-  OPEN62541_COMPAT_VERSION: v1.5.5
+  OPEN62541_COMPAT_VERSION: v1.5.6
 
 jobs:
 


### PR DESCRIPTION
Bumps the LogIt submodule to the **`v1.0.x` maintenance branch** (v1.0.0 + cmake floor 3.16 per [OPCUA-3365](https://its.cern.ch/jira/browse/OPCUA-3365), `BUILD/INSTALL_INTERFACE` include dirs per [OPCUA-3336](https://its.cern.ch/jira/browse/OPCUA-3336), warning-clean sink headers per LogIt PR #17 / DCS-614) and the compat pin to v1.5.6 (same LogIt pin on the compat side).

This makes the framework's earlier de-`-isystem` of LogIt sound: its premise (warning-clean headers) is now true in the consumed tree.

**Verification**: LogIt branch green under CMake 3.16.3 / 3.31.8 / 4.0.3 (+ `install(EXPORT)` consumer smoke; v1.0.0 negative control fails under CMake 4 as expected). AtcaOpcUa full rebuild in the parity harness under gcc 16.1 with its own strict `-Werror` set and the harness's `-Wno-error` suppression **removed** — builds clean, runs, probes, address-space sha bit-identical. compat standalone 50/50 with the same pin.