### PR TITLE
OPCUA-3391: compiler support matrix + clang-tidy workflow off the alma9 image

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -11,7 +11,7 @@ on:
       open62541_compat_branch:
         description: 'open62541-compat branch/tag'
         required: false
-        default: 'v1.4.3-rc0'
+        default: 'v1.5.6'
       filter:
         description: 'substring filter on TU paths (optional)'
         required: false
@@ -21,7 +21,7 @@ jobs:
   clang-tidy:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/quasar-team/quasar-uasdk:latest
+      image: ghcr.io/quasar-team/quasar-uasdk:alma10
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/Documentation/source/quasar.rst
+++ b/Documentation/source/quasar.rst
@@ -82,7 +82,13 @@ For remaining systems (other distros of Linux, other Unix, embedded Linux: PetaL
 Mandatory:
 ^^^^^^^^^^
 
--  C++ compiler with C++11 support (gcc 11.x is the minimum)
+-  C++ compiler with C++11 support (gcc 11.x is the minimum). clang is
+   also supported and covered by CI on AlmaLinux 10 (the distribution's
+   clang against the OS Boost 1.83). On AlmaLinux 9, where the OS Boost
+   is 1.75, use the AppStream ``clang15`` package: clang 19 and newer
+   cannot compile the Boost 1.75 headers (a ``boost::numeric_cast`` /
+   Boost.MPL constant-expression error; a limitation of that Boost
+   release, not of quasar — see OPCUA-3391).
 
 -  OPCUA protocol stacks / toolkits (either of them is needed):
    -  see `More info on alternative backends <AlternativeBackends.html>`__.


### PR DESCRIPTION
## OPCUA-3391 — settle the clang / AlmaLinux 9 stock Boost 1.75 tracker

Stock Alma9 Boost 1.75 does not compile under clang >= 19 (boost::numeric_cast -> boost/mpl `integral_wrapper` "non-type template argument is not a constant expression"); clang 15 works, gcc works. Verified boundary (ticket evidence): clang 15.0.7 OK / 19.1.7 FAIL / 21.1.8 FAIL. The clang compile CI job already moved to the alma10 image (Boost 1.83, rolling clang) in 984c9c7 (OPCUA-3341). This PR settles what remains:

1. **Document the compiler support matrix** (`Documentation/source/quasar.rst`): gcc 11.x minimum; clang covered by CI on AlmaLinux 10 (OS Boost 1.83, rolling clang); on AlmaLinux 9 with the OS Boost 1.75 use the AppStream `clang15` package — clang >= 19 fails in the OS Boost headers (OS limitation, not quasar).
2. **Move the manual clang-tidy workflow off the alma9 image** (`.github/workflows/clang-tidy.yml`): it was the last place a rolling clang frontend parsed Boost 1.75 (unpinned `clang-tools-extra` on alma9 AppStream LLVM >= 19). Now runs on `quasar-uasdk:alma10`, mirroring 984c9c7; stale default `open62541_compat_branch` bumped v1.4.3-rc0 -> v1.5.6 to match ci.yml's pin.

Repo audit (no other exposure): no quasar-team docker image bakes clang (alma9 `Dockerfile` and `Dockerfile.alma10` install gcc-c++ only — clang is installed at CI runtime); no workflow compiles with clang on alma9; docs nowhere claimed clang-on-alma9 support.

### Verification
- RST: docutils 0.21.2 parse before/after — zero new warnings (single pre-existing 'Title underline too short' at the AlmaLinux-9 heading unchanged).
- YAML: clang-tidy.yml validates with yaml.safe_load after the edit.
- clang-tidy smoke run from this branch (alma10 image, compat v1.5.6): null (null)
- Full CI matrix on this PR: gating merge (will be awaited before merging).