### PR TITLE
DCS-630: QuasarThreadPool: name the most common cause in the missing-LogIt-handle throw

### DIFF
--- a/Common/src/QuasarThreadPool.cpp
+++ b/Common/src/QuasarThreadPool.cpp
@@ -35,7 +35,7 @@ ThreadPool::ThreadPool (unsigned int maxThreads, unsigned int maxJobs):
 {
     m_threadPoolLogId = Log::getComponentHandle("ThreadPool");
     if (m_threadPoolLogId == Log::INVALID_HANDLE)
-        throw std::logic_error("ThreadPool initialized before ThreadPool LogIt handle is initialized");
+        throw std::logic_error("ThreadPool initialized before ThreadPool LogIt handle is initialized -- most common cause: QuasarServer::initializeLogIt() override does not delegate to BaseQuasarServer::initializeLogIt(), which registers the ThreadPool logging component");
     m_workers.reserve(maxThreads);
     for (unsigned int i=0; i<maxThreads; ++i)
         m_workers.emplace_back( [this](){this->work();} );


### PR DESCRIPTION
## What

One line: the `std::logic_error` thrown by `Quasar::ThreadPool`'s constructor when the "ThreadPool" LogIt handle is missing (`Common/src/QuasarThreadPool.cpp:38`) now names the most common cause and the fix:

```
ThreadPool initialized before ThreadPool LogIt handle is initialized -- most common cause: QuasarServer::initializeLogIt() override does not delegate to BaseQuasarServer::initializeLogIt(), which registers the ThreadPool logging component
```

## Why

Quasar-1.3-vintage projects carry a user-code `QuasarServer::initializeLogIt()` override whose body is a bare `Log::initializeLogging()`. `Server/src/QuasarServer.cpp` is `copy_if_not_existing`, so `upgrade_project` never rewrites it; on quasar >= 2.0 the SourceVariableThreadPool construction then aborts the server at startup with the old riddle-message. This killed three production ATLAS DCS servers on their first quasar-2.x deployment (OpcUaGFexServer, OpcUaGenericSnmp, OpcUaFtkSbcServer — DCS-630), and a sweep of 38 quasar projects found two more affected (OpcUaIpBusServer, OpcUaLArPurityServer). The remedy has been documented in the ChangeLog since OPCUA-696 (~2018) — demonstrably insufficient, because nothing connects the runtime message to that doc.

The throw itself stays: self-registering the component here would mask that the override also skipped CalcVars/AddressSpace registration (deliberate fail-fast design). Only the message gets actionable.

## Risk / verification

- Message string only; zero control-flow or behavior change for healthy servers.
- Nothing in-tree asserts on the message text (the only ThreadPool test, `Common/test/test_quasar_threadpool.cpp`, is a manual `BUILD_QUASAR_TESTS`-gated program that doesn't check the text).
- Message **prefix is unchanged**, so external log-matching on the old string keeps working.
- Exercised at compile level by every job of the CI server matrix (all build `QuasarThreadPool.cpp`).
- Runtime check of the new message performed in the open62541/UASDK parity harness: an OpcUaGFexServer build at pristine vintage HEAD reproduces the startup abort; the per-server one-line delegation fixes (prepared as MRs to the affected repos) make it run and serve its full address space.