### PR TITLE
OPCUA-3416: Document case-insensitive naming requirement for custom-module public headers

### DIFF
--- a/Documentation/source/quasarBuildSystem.rst
+++ b/Documentation/source/quasarBuildSystem.rst
@@ -117,6 +117,27 @@ Custom module deployment is comprised of:
 After both steps the quasar build system will take the custom module
 into account.
 
+Naming of custom-module public headers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The include/ directories of all enabled modules share one include search
+path, with the native modules listed first (in the order AddressSpace,
+Configuration, Common, Server, Device, Meta, LogIt, CalculatedVariables),
+then optional modules, then custom modules. A public header of a custom
+module must therefore not carry the same file name as any framework
+header, and the names must differ **case-insensitively**: on
+case-insensitive file systems (macOS, Windows — and Linux containers
+building from a directory mounted off such a host) the preprocessor
+matches header names without regard to case. For example, a custom
+module shipping ``include/Meta.h`` builds fine on Linux CI but breaks on
+macOS checkouts: ``#include <Meta.h>`` resolves to the framework Meta
+module's ``meta.h``, which sits earlier on the include path, and the
+intended header is never seen. Note that reordering the include path
+would not fix such a collision — it would instead silently serve the
+custom module's header to framework code including ``<meta.h>``. Choose
+distinctive names for custom-module public headers, e.g. prefixed with
+the module name (see OPCUA-3416).
+
 Device class file ownership
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## What

Adds a "Naming of custom-module public headers" subsection to `Documentation/source/quasarBuildSystem.rst` (custom-module deployment chapter): custom-module public headers must differ **case-insensitively** from framework headers, with the real-world `Meta.h` vs `meta.h` example and an explanation of why include-path reordering is not a fix.

## Why (OPCUA-3416)

Hit by the backend-parity campaign on the `opcualarltdbserver` cells: the server's custom module `UaoClientForOpcUaSca` ships `include/Meta.h`; the framework Meta module ships `include/meta.h`. Quasar's include path lists native module include dirs before custom ones (`CMakeLists.txt`: `NATIVE_SERVER_MODULES` then `CUSTOM_SERVER_MODULES`, each contributing `<module>/include`). On a case-insensitive filesystem (macOS APFS checkout, incl. when bind-mounted into a Linux build container) `#include <Meta.h>` therefore resolves to the framework's `meta.h`, and compilation fails with e.g. `error: no type named 'Meta' in namespace 'UaoClientForOpcUaSca'`. The same tree builds fine on Linux CI.

## Why a doc note and not an include-order change

Framework code itself includes the lowercase header (`Server/src/BaseQuasarServer.cpp`, `Meta/src/meta.cpp`, and generated Configurators via `Configuration/templates/designToConfigurator.jinja`). Putting custom-module include dirs first would silently serve the custom `Meta.h` to those framework TUs on the same filesystems — verified both directions with `clang -H`: with the current order `<Meta.h>` hits `Meta/include/meta.h`; with the reversed order `<meta.h>` hits the custom `Meta.h`. No ordering is safe when basenames collide case-insensitively; only distinct names are.

An estate-wide scan of the ATLAS DCS quasar server repos found exactly one case-differing collision (this `Meta.h`), so a documented naming requirement is proportionate.

## Verification

- Doc-only change: `docutils` parse of the edited file reports no warnings.
- Matches the format precedent of the recent compiler-support-matrix note (OPCUA-3391, #373).