### PR TITLE
OPCUA-3418: open62541-compat v1.5.7 (Windows embedded-link fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 env:
-  OPEN62541_COMPAT_VERSION: v1.5.6
+  OPEN62541_COMPAT_VERSION: v1.5.7
 
 jobs:
 


### PR DESCRIPTION
Pin bump for the iphlpapi amalgamation pragma (compat PR #116 / OPCUA-3418): quasar-embedded MSVC links no longer drop iphlpapi, fixing LNK2019 __imp_GetAdaptersAddresses reported by the JCOP quasar-tma Windows pipeline. Full matrix gates this merge.