### PR TITLE
ci: user-code canary for the generated Configuration API

### DIFF
--- a/.CI/test_cases/manifest.json
+++ b/.CI/test_cases/manifest.json
@@ -138,6 +138,7 @@
       "design": "test_config_entries/Design.xml",
       "config": "test_config_entries/config.xml",
       "generate_devices": true,
+      "device_sources": "test_config_entries",
       "oracle": "test_config_entries/reference_ns2.xml",
       "backends": [
         "o6",

--- a/.CI/test_cases/test_config_entries/DTestClass.test.cpp
+++ b/.CI/test_cases/test_config_entries/DTestClass.test.cpp
@@ -1,0 +1,45 @@
+/*  © Copyright CERN, 2026. All rights not expressly granted are reserved.
+    @author Paris Moschovakos
+
+    Quasar is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public Licence as published by
+    the Free Software Foundation, either version 3 of the Licence.
+    Quasar is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public Licence for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with Quasar.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Configuration.hxx>
+
+#include <DTestClass.h>
+#include <ASTestClass.h>
+
+namespace Device
+{
+
+DTestClass::DTestClass (
+    const Configuration::TestClass & config,
+    Parent_DTestClass * parent
+):
+    Base_DTestClass( config, parent),
+    m_uint32Entry( config.OpcUaUInt32_scalar() ),
+    m_booleanEntry( config.OpcUaBoolean_scalar() )
+{
+}
+
+DTestClass::~DTestClass ()
+{
+}
+
+std::unique_ptr<Configuration::Configuration> DTestClass::parseLikeDownstreamUserCode ( const std::string& fileName )
+{
+    std::unique_ptr<Configuration::Configuration> configuration =
+        Configuration::configuration( fileName, ::xml_schema::flags::keep_dom );
+    return configuration;
+}
+
+}

--- a/.CI/test_cases/test_config_entries/DTestClass.test.h
+++ b/.CI/test_cases/test_config_entries/DTestClass.test.h
@@ -1,0 +1,59 @@
+/*  © Copyright CERN, 2026. All rights not expressly granted are reserved.
+    @author Paris Moschovakos
+
+    Quasar is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public Licence as published by
+    the Free Software Foundation, either version 3 of the Licence.
+    Quasar is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public Licence for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with Quasar.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __DTestClass__H__
+#define __DTestClass__H__
+
+#include <memory>
+#include <string>
+
+#include <Configuration.hxx>
+
+#include <Base_DTestClass.h>
+
+namespace Device
+{
+
+class
+    DTestClass
+    : public Base_DTestClass
+{
+
+public:
+    explicit DTestClass (
+        const Configuration::TestClass& config,
+        Parent_DTestClass* parent
+    ) ;
+    ~DTestClass ();
+
+    // Canary for the downstream-user-code contract of the xsd-generated
+    // Configuration (OPCUA-3456): pins the parse function's smart-pointer
+    // species (unique_ptr, from xsdcxx --std c++11) and the configentry
+    // accessors. Never called at runtime; a codegen or toolchain change that
+    // breaks user servers breaks this compile first.
+    std::unique_ptr<Configuration::Configuration> parseLikeDownstreamUserCode ( const std::string& fileName );
+
+private:
+    DTestClass( const DTestClass& other );
+    DTestClass& operator=(const DTestClass& other);
+
+    unsigned int m_uint32Entry;
+    bool m_booleanEntry;
+
+};
+
+}
+
+#endif // __DTestClass__H__

--- a/.github/actions/build-uasak-dump/action.yml
+++ b/.github/actions/build-uasak-dump/action.yml
@@ -112,7 +112,7 @@ runs:
         #    that uasak's include_directories doesn't cover -> add them to cl's INCLUDE.
         $env:LIB = "$env:LIB;C:\vcpkg\installed\x64-windows\lib"
         $env:INCLUDE = "$env:INCLUDE;$env:CODE_SYNTHESYS_XSD_PATH_HEADERS;C:\vcpkg\installed\x64-windows\include"
-        cmake -S . -B build -G Ninja $policy -DCMAKE_BUILD_TYPE=Release @boost -DXSD_CXX_COMMAND=xsd -DCMAKE_EXE_LINKER_FLAGS="/LIBPATH:C:\vcpkg\installed\x64-windows\lib /LIBPATH:C:\deps\boost\libs"; chk "uasak configure"
+        cmake -S . -B build -G Ninja $policy -DCMAKE_BUILD_TYPE=Release @boost -DXSD_CXX_COMMAND=xsdcxx -DCMAKE_EXE_LINKER_FLAGS="/LIBPATH:C:\vcpkg\installed\x64-windows\lib /LIBPATH:C:\deps\boost\libs"; chk "uasak configure"
         cmake --build build; chk "uasak build"
         Get-ChildItem -Recurse -Filter 'uasak_dump*' build | Select-Object FullName
 

--- a/.github/actions/setup-quasar-windows/action.yml
+++ b/.github/actions/setup-quasar-windows/action.yml
@@ -36,16 +36,30 @@ runs:
         Write-Host "Boost include root: $boostInc"
         "BOOST_PATH_HEADERS=$boostInc" >> $env:GITHUB_ENV
         "BOOST_PATH_LIBS=C:\deps\boost" >> $env:GITHUB_ENV
-    - name: Provision CodeSynthesis XSD (xsd.exe + libxsd)
+    # Mirrors BE-ICS w2025 Install-Xsd.ps1 / Install-LibXsd.ps1 (jcop-opc-ua/common/images):
+    # the binary is installed as xsdcxx.exe because VS developer prompts already carry
+    # Microsoft's .NET xsd.exe on PATH -- same clash the Debian rename avoids.
+    - name: Provision CodeSynthesis XSD (xsdcxx.exe + libxsd)
       shell: pwsh
       run: |
-        Invoke-WebRequest "https://www.codesynthesis.com/download/xsd/4.0/windows/i686/xsd-4.0.0-i686-windows.zip" -OutFile xsd.zip
+        $xsdHome='C:\deps\xsd'
+        Invoke-WebRequest "https://www.codesynthesis.com/download/xsd/4.2/windows/windows10/x86_64/xsd-4.2.0-x86_64-windows10.zip" -OutFile xsd.zip
         Expand-Archive xsd.zip C:\deps\xsd-dl -Force
-        $xsdexe=(Get-ChildItem C:\deps\xsd-dl -Recurse -Filter xsd.exe | Select-Object -First 1).FullName
-        $libxsd=(Get-ChildItem C:\deps\xsd-dl -Recurse -Directory -Filter libxsd | Select-Object -First 1).FullName
-        "CODE_SYNTHESYS_XSD_PATH_HEADERS=$libxsd" >> $env:GITHUB_ENV
-        (Split-Path $xsdexe) >> $env:GITHUB_PATH
-        Write-Host "xsd.exe=$xsdexe"; Write-Host "libxsd=$libxsd"
+        $xsdexe=Get-ChildItem C:\deps\xsd-dl -Recurse -Filter xsd.exe -File | Select-Object -First 1
+        if (-not $xsdexe) { throw "xsd.exe not found in the XSD package" }
+        New-Item -ItemType Directory -Force $xsdHome | Out-Null
+        Copy-Item $xsdexe.FullName (Join-Path $xsdHome 'xsdcxx.exe') -Force
+        Invoke-WebRequest "https://www.codesynthesis.com/download/xsd/4.2/libxsd-4.2.0.tar.gz" -OutFile libxsd.tar.gz
+        New-Item -ItemType Directory -Force C:\deps\libxsd-src | Out-Null
+        tar -xzf libxsd.tar.gz -C C:\deps\libxsd-src
+        $src=Get-ChildItem C:\deps\libxsd-src -Directory | Select-Object -First 1
+        if (-not (Test-Path "$($src.FullName)\xsd\cxx")) { throw "libxsd headers not found under $($src.FullName)" }
+        $hdrs=Join-Path $xsdHome 'include\xsd\cxx'
+        New-Item -ItemType Directory -Force $hdrs | Out-Null
+        Copy-Item "$($src.FullName)\xsd\cxx\*" $hdrs -Recurse -Force
+        "CODE_SYNTHESYS_XSD_PATH_HEADERS=$xsdHome\include" >> $env:GITHUB_ENV
+        $xsdHome >> $env:GITHUB_PATH
+        Write-Host "xsdcxx.exe=$xsdHome\xsdcxx.exe"; Write-Host "libxsd=$xsdHome\include"
     # Cache the built vcpkg deps. Split restore/save so the cache is written
     # right after vcpkg (before the build step that may still fail) -- the
     # combined cache action skips saving on a failed job, which is why earlier


### PR DESCRIPTION
Motivated by the CAEN Windows migration hitting C2440 (unique_ptr vs auto_ptr) in user code against the xsd-generated Configuration: the config_entries case now overlays a hand-written D-class that consumes the Configuration API the way downstream servers do (configentry accessors + the unique_ptr-returning parse function). A codegen or toolchain change that breaks user servers now breaks quasar CI first, on every backend and OS. Stacked on #382.