### PR TITLE
ci: UASDK PR gate moves to 2.0.3

### DIFF
--- a/.CI/expand_matrix.py
+++ b/.CI/expand_matrix.py
@@ -106,10 +106,6 @@ def expand(manifest):
     # pass/fail signal is case-INDEPENDENT, so only a few broad-surface cases need re-run there.
     # Empty/absent => keep the full case set (current behaviour).
     representative = set(manifest.get('representative_cases', []))
-    # PR-tier (default) uasdk versions: these keep the FULL case set on default_os. Non-default
-    # (nightly) versions are a framework/SDK-level delta and only re-run the representative cases.
-    pr_uasdk_versions = {tk['version'] for tk in toolkits.get('uasdk', [])
-                         if tk.get('tier', 'pr') == 'pr'}
 
     def in_rep(case):
         return (not representative) or case['name'] in representative
@@ -139,12 +135,15 @@ def expand(manifest):
             for arch in default_arches:
                 # default_os x86_64: every toolkit version fans out per its own 'cases'
                 # list (absent = full case set) at its own tier. On an alt default arch
-                # (e.g. arm64) only the PR-default version has an arch image, so cases run
-                # there against just that version (o6 + uasdk-<default>), PR tier.
+                # (e.g. arm64) a version reaches the sweep only if it declares an image
+                # for that arch (toolkit 'arches', default x86_64-only), each at its own
+                # tier -- so the PR gate can move to a version whose alt-arch image
+                # doesn't exist yet without breaking the alt-arch cells.
                 if arch == 'x86_64':
                     only_v = None
                 else:
-                    only_v = pr_uasdk_versions
+                    only_v = {tk['version'] for tk in toolkits.get('uasdk', [])
+                              if arch in tk.get('arches', ['x86_64'])}
                 cells += emit(case, backend, default_os, 'gcc', case_tier,
                               only_versions=only_v, arch=arch)
         for extra in case.get('extra_cells', []):

--- a/.CI/test_cases/manifest.json
+++ b/.CI/test_cases/manifest.json
@@ -31,7 +31,7 @@
     "uasdk": [
       {
         "version": "1.8.9",
-        "tier": "pr"
+        "tier": "nightly"
       },
       {
         "version": "1.6.5",
@@ -42,7 +42,7 @@
       },
       {
         "version": "2.0.3",
-        "tier": "nightly"
+        "tier": "pr"
       }
     ]
   },

--- a/.CI/test_cases/manifest.json
+++ b/.CI/test_cases/manifest.json
@@ -31,7 +31,11 @@
     "uasdk": [
       {
         "version": "1.8.9",
-        "tier": "nightly"
+        "tier": "nightly",
+        "arches": [
+          "x86_64",
+          "arm64"
+        ]
       },
       {
         "version": "1.6.5",
@@ -42,7 +46,10 @@
       },
       {
         "version": "2.0.3",
-        "tier": "pr"
+        "tier": "pr",
+        "arches": [
+          "x86_64"
+        ]
       }
     ]
   },

--- a/.github/actions/build-uasak-dump/action.yml
+++ b/.github/actions/build-uasak-dump/action.yml
@@ -112,7 +112,7 @@ runs:
         #    that uasak's include_directories doesn't cover -> add them to cl's INCLUDE.
         $env:LIB = "$env:LIB;C:\vcpkg\installed\x64-windows\lib"
         $env:INCLUDE = "$env:INCLUDE;$env:CODE_SYNTHESYS_XSD_PATH_HEADERS;C:\vcpkg\installed\x64-windows\include"
-        cmake -S . -B build -G Ninja $policy -DCMAKE_BUILD_TYPE=Release @boost -DXSD_CXX_COMMAND=xsd -DCMAKE_EXE_LINKER_FLAGS="/LIBPATH:C:\vcpkg\installed\x64-windows\lib /LIBPATH:C:\deps\boost\libs"; chk "uasak configure"
+        cmake -S . -B build -G Ninja $policy -DCMAKE_BUILD_TYPE=Release @boost -DXSD_CXX_COMMAND=xsdcxx -DCMAKE_EXE_LINKER_FLAGS="/LIBPATH:C:\vcpkg\installed\x64-windows\lib /LIBPATH:C:\deps\boost\libs"; chk "uasak configure"
         cmake --build build; chk "uasak build"
         Get-ChildItem -Recurse -Filter 'uasak_dump*' build | Select-Object FullName
 

--- a/.github/actions/setup-quasar-windows/action.yml
+++ b/.github/actions/setup-quasar-windows/action.yml
@@ -36,16 +36,30 @@ runs:
         Write-Host "Boost include root: $boostInc"
         "BOOST_PATH_HEADERS=$boostInc" >> $env:GITHUB_ENV
         "BOOST_PATH_LIBS=C:\deps\boost" >> $env:GITHUB_ENV
-    - name: Provision CodeSynthesis XSD (xsd.exe + libxsd)
+    # Mirrors BE-ICS w2025 Install-Xsd.ps1 / Install-LibXsd.ps1 (jcop-opc-ua/common/images):
+    # the binary is installed as xsdcxx.exe because VS developer prompts already carry
+    # Microsoft's .NET xsd.exe on PATH -- same clash the Debian rename avoids.
+    - name: Provision CodeSynthesis XSD (xsdcxx.exe + libxsd)
       shell: pwsh
       run: |
-        Invoke-WebRequest "https://www.codesynthesis.com/download/xsd/4.0/windows/i686/xsd-4.0.0-i686-windows.zip" -OutFile xsd.zip
+        $xsdHome='C:\deps\xsd'
+        Invoke-WebRequest "https://www.codesynthesis.com/download/xsd/4.2/windows/windows10/x86_64/xsd-4.2.0-x86_64-windows10.zip" -OutFile xsd.zip
         Expand-Archive xsd.zip C:\deps\xsd-dl -Force
-        $xsdexe=(Get-ChildItem C:\deps\xsd-dl -Recurse -Filter xsd.exe | Select-Object -First 1).FullName
-        $libxsd=(Get-ChildItem C:\deps\xsd-dl -Recurse -Directory -Filter libxsd | Select-Object -First 1).FullName
-        "CODE_SYNTHESYS_XSD_PATH_HEADERS=$libxsd" >> $env:GITHUB_ENV
-        (Split-Path $xsdexe) >> $env:GITHUB_PATH
-        Write-Host "xsd.exe=$xsdexe"; Write-Host "libxsd=$libxsd"
+        $xsdexe=Get-ChildItem C:\deps\xsd-dl -Recurse -Filter xsd.exe -File | Select-Object -First 1
+        if (-not $xsdexe) { throw "xsd.exe not found in the XSD package" }
+        New-Item -ItemType Directory -Force $xsdHome | Out-Null
+        Copy-Item $xsdexe.FullName (Join-Path $xsdHome 'xsdcxx.exe') -Force
+        Invoke-WebRequest "https://www.codesynthesis.com/download/xsd/4.2/libxsd-4.2.0.tar.gz" -OutFile libxsd.tar.gz
+        New-Item -ItemType Directory -Force C:\deps\libxsd-src | Out-Null
+        tar -xzf libxsd.tar.gz -C C:\deps\libxsd-src
+        $src=Get-ChildItem C:\deps\libxsd-src -Directory | Select-Object -First 1
+        if (-not (Test-Path "$($src.FullName)\xsd\cxx")) { throw "libxsd headers not found under $($src.FullName)" }
+        $hdrs=Join-Path $xsdHome 'include\xsd\cxx'
+        New-Item -ItemType Directory -Force $hdrs | Out-Null
+        Copy-Item "$($src.FullName)\xsd\cxx\*" $hdrs -Recurse -Force
+        "CODE_SYNTHESYS_XSD_PATH_HEADERS=$xsdHome\include" >> $env:GITHUB_ENV
+        $xsdHome >> $env:GITHUB_PATH
+        Write-Host "xsdcxx.exe=$xsdHome\xsdcxx.exe"; Write-Host "libxsd=$xsdHome\include"
     # Cache the built vcpkg deps. Split restore/save so the cache is written
     # right after vcpkg (before the build step that may still fail) -- the
     # combined cache action skips saving on a failed job, which is why earlier


### PR DESCRIPTION
BE-ICS builds and ships UASDK 2.0.3-681 (their w2025 images); our PR gate was still 1.8.9, so every PR was tested against a version they no longer run. 2.0.3 becomes the PR tier on Linux and Windows (same manifest), 1.8.9 moves to nightly.

Toolkit versions now declare their arches in the manifest: arm64 cells fan out only for versions that have an arm64 image. Until a 2.0.3 arm64 image exists, uasdk arm64 coverage runs at nightly on 1.8.9.

Stacked on #382.