### PR TITLE
ci(windows): images pin moves to the merged main commit

### DIFF
--- a/.github/actions/setup-quasar-windows/action.yml
+++ b/.github/actions/setup-quasar-windows/action.yml
@@ -26,14 +26,14 @@ runs:
       run: |
         python -m pip install jinja2 lxml colorama pygit2
         choco install astyle -y --no-progress
-    # The pin is the w2025-jcop-sync branch of quasar-team/images -- a verbatim
+    # The pin is a main commit of quasar-team/images -- a verbatim
     # snapshot of jcop-opc-ua/common/images (the scripts BE-ICS builds their WS25
     # CI images and dev envs from). Bump the ref to pick up their changes.
     - name: Pin the BE-ICS w2025 image scripts
       id: images
       shell: pwsh
       run: |
-        $ref='44e4fd7730025a9be1b8d4209776f5399f7ac995'
+        $ref='3c33ca115b35a30fa4be26be2db37046eb2286eb'
         git clone -q https://github.com/quasar-team/images.git C:\deps\images
         git -C C:\deps\images checkout -q $ref
         "ref=$ref" >> $env:GITHUB_OUTPUT

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -436,7 +436,7 @@ jobs:
         run: |
           pin=$(grep -oE "'[0-9a-f]{40}'" .github/actions/setup-quasar-windows/action.yml | tr -d "'" | head -1)
           [ -n "$pin" ] || { echo "::error::could not extract the images pin from setup-quasar-windows"; exit 1; }
-          tips=$(git ls-remote https://github.com/quasar-team/images.git refs/heads/main refs/heads/w2025-jcop-sync | cut -f1)
+          tips=$(git ls-remote https://github.com/quasar-team/images.git refs/heads/main | cut -f1)
           echo "pin:  $pin"
           echo "tips:"; echo "$tips"
           if echo "$tips" | grep -q "^$pin$"; then


### PR DESCRIPTION
quasar-team/images#10 landed as a rebase-merge, so the pinned w2025 provisioning commit now exists on main as 3c33ca1. Point the pin (and the drift probe) at main; afterwards the temporary w2025-jcop-sync branch can go. New pin means one cold dep-cache rebuild.

https://its.cern.ch/jira/browse/OPCUA-3458